### PR TITLE
UNPQ-15 Create Request class

### DIFF
--- a/Connection.cpp
+++ b/Connection.cpp
@@ -34,11 +34,8 @@ Connection* Connection::acceptClient() {
     return new Connection(clientfd, addr, remoteaddr.sin_port);
 }
 
-void Connection::receive() {
-    unsigned char buffer[TCP_MTU];
-
-    recv(_ident, buffer, TCP_MTU, 0);
-    Log::Verbose("receive works");
+ReturnCaseOfRecv Connection::receive() {
+    return this->_request.receive(this->_ident);
 }
 
 //  Send response message to client.

--- a/Connection.hpp
+++ b/Connection.hpp
@@ -11,8 +11,6 @@
 #include "Request.hpp"
 #include "Response.hpp"
 
-#define TCP_MTU 1500
-
 //  General coonection handler, from generation communication.
 //   - TODO
 //      Connection should handle the receiving and transmiting without malfunction.
@@ -30,7 +28,7 @@ public:
     Connection(int port);
 
     Connection* acceptClient();
-    void receive();
+    ReturnCaseOfRecv receive();
     void transmit();
     void addKevent(int kqueue, int filter, void* udata);
 
@@ -39,7 +37,6 @@ public:
     std::string getAddr() { return this->_addr; };
     int getPort() { return this->_port; };
     const Request& getRequest() const { return this->_request; };
-    void addReceivedLine(const std::string& line) { this->_request.appendMessage(line); };
     void setResponse();
 
 private:

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -128,7 +128,7 @@ void FTServer::read(Connection* connection) {
             VirtualServer& targetVirtualServer = this->getTargetVirtualServer(*connection);
             targetVirtualServer.process(*connection, this->_kqueue);
             break;
-        defaut:
+        default:
             assert(false);
             break;
     }

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include "FTServer.hpp"
 #include "VirtualServer.hpp"
 #include "Request.hpp"
@@ -105,24 +106,40 @@ void FTServer::clientAccept(Connection* connection) {
     Log::Verbose("Client Accepted: [%s]", newConnection->getAddr().c_str());
 }
 
+//  Read and process requested by client.
+//  - Parameters connection: The connection to read from.
+//  - Return(None)
 void FTServer::read(Connection* connection) {
-    std::string line;
+    ReturnCaseOfRecv result = connection->receive();
 
-    connection->receive();
-
-    connection->addReceivedLine(line);
-    VirtualServer& targetVirtualServer = this->getTargetVirtualServer(*connection);
-
-    if (connection->getRequest().isReady())
-        targetVirtualServer.process(*connection, this->_kqueue); 
+    switch (result) {
+        case RCRECV_ERROR:
+            //  TODO Implement behavior
+            break;
+        case RCRECV_ZERO:
+            //  TODO Implement behavior
+            break;
+        case RCRECV_SOME:
+            break;
+        case RCRECV_PARSING_FAIL:
+            //  TODO Implement behavior
+            break;
+        case RCRECV_PARSING_SUCCESS:
+            VirtualServer& targetVirtualServer = this->getTargetVirtualServer(*connection);
+            targetVirtualServer.process(*connection, this->_kqueue);
+            break;
+        defaut:
+            assert(false);
+            break;
+    }
 }
 
-//  TODO Implement real behavior
 //  Return appropriate server to process client connection.
 //  - Parameters
 //      clientConnection: The connection for client.
 //  - Returns: Appropriate server to process client connection.
 VirtualServer& FTServer::getTargetVirtualServer(Connection& clientConnection) {
+    //  TODO Implement real behavior. Change the return type from reference to pointer type.
     (void)clientConnection;
     return *this->_vVirtualServers[0];
 }

--- a/Request.cpp
+++ b/Request.cpp
@@ -1,97 +1,186 @@
+#include <sys/socket.h>
 #include <sstream>
 #include <string>
 #include <ctype.h>
 #include <cassert>
 #include "Request.hpp"
 
-// constant
-const int NORMAL = 0;
-const int ERROR = -1;
+//  Destructor of Request object.
+Request::~Request() {
+    for (HeaderSectionType::iterator iter = this->_headerSection.begin(); iter != this->_headerSection.end(); ++iter)
+        delete *iter;
+}
 
-static void initMethod(Method& method, const std::string& token);
-static int initVersion(char& majorVersion, char& minorVersion, const std::string& token);
+//  Returns first header field value of name.
+//  - Parameters name: The name to search value.
+//  - Return: The first header field value of name
+const std::string* Request::getFirstHeaderFieldValueByName(const std::string& name) {
+    for (HeaderSectionType::iterator iter = this->_headerSection.begin(); iter != this->_headerSection.end(); ++iter)
+        if ((*iter)->first == name)
+            return &(*iter)->second;
 
-//  TODO extraction error if not, abort might occur.
-//  Parse HTTP request message.
-void Request::parse() {
-    std::stringstream ss(this->_message);
-    std::string token;
+    return (NULL);
+}
 
-    ss >> token;
-    initMethod(this->_method, token);
+//  Receive message from client. If the message is ready to process, parse it.
+//  - Parameters clientSocketFD: The fd to recv().
+//  - Return: See the type definition.
+ReturnCaseOfRecv Request::receive(int clientSocketFD) {
+    ssize_t result = this->receiveMessage(clientSocketFD);
+    if (result == -1)
+        return RCRECV_ERROR;
+    else if (result == 0)
+        return RCRECV_ZERO;
 
-    ss >> token;
-    this->_target = token;
-
-    ss >> token;
-    initVersion(this->_majorVersion, this->_minorVersion, token);
-
-    char ch;
-    while (isspace(ch = ss.get()));
-    ss.putback(ch);
-    while (std::getline(ss, token, (char)0x0d)) {
-        if (token.length() == 0) {
-            ss.get();
-            break;
-        }
-        std::string::size_type colon_position = token.find(':');
-        const std::string key = token.substr(0, colon_position);
-        const std::string value = token.substr(colon_position + 2);
-        this->_headerFieldMap[key] = value;
-        ss.get();
+    if (this->isReadyToProcess()) {
+        if (this->parseMessage() == PR_SUCCESS) // TODO Pass valid string to parseMessage and left remain string.
+            return RCRECV_PARSING_SUCCESS;
+        else
+            return RCRECV_PARSING_FAIL;
     }
 
-    if (ss.eof())
-        return;
+    return RCRECV_SOME;
+}
+
+//  Receive message from client.
+//  - Parameters clientSocketFD: The fd to recv().
+//  - Return: the result of recv() call.
+ssize_t Request::receiveMessage(int clientSocketFD) {
+    char buf[BUF_SIZE];
+
+    ssize_t result = recv(clientSocketFD, buf, BUF_SIZE, 0);
+    if (result <= 0)
+        return result;
+
+    this->appendMessage(buf);
+
+    return result;
+}
+
+//  Append received message from client.
+//  - Parameters message: The string of message received from client.
+//  - Return(None)
+void Request::appendMessage(const char* message) {
+    this->_message += message;
+}
+
+//  Returns whether Request received the end of header section or not.
+//  - Parameters(None)
+//  - Return: Whether request received the end of header section or not.
+bool Request::isReadyToProcess() const {
+    return (this->_message.find("\x0d\x0a\x0d\x0a") != std::string::npos);
+}
+
+//  Parse HTTP request message.
+//  - Parameters(None)
+//  - Return: Whether the parsing succeeded or not.
+ParsingResult Request::parseMessage() {
+    std::istringstream iss(this->_message);
+    std::string line;
+
+    if (!std::getline(iss, line, '\x0d'))
+        return PR_FAIL;
+    if (this->parseRequestLine(line) == PR_FAIL)
+        return PR_FAIL;
+
+    while (true) {
+        if (iss.get() == EOF || !iss)
+            return PR_FAIL;
+        if (!std::getline(iss, line, '\x0d'))
+            return PR_FAIL;
+        if (line.empty())
+            break;
+        if (parseHeader(line) == PR_FAIL)
+            return PR_FAIL;
+    }
+
+    if (iss.get() == EOF || !iss)
+        return PR_FAIL;
+
+    this->_body = this->_message.substr(iss.tellg());
+
+    return PR_SUCCESS;
+}
+
+//  Parse HTTP request line.
+//  - Parameters requestLine: The string of request line.
+//  - Return: Whether the parsing succeeded or not.
+ParsingResult Request::parseRequestLine(const std::string& requestLine) {
+    std::istringstream iss(requestLine);
+    std::string token;
+
+    if (iss >> token)
+        this->_method = requestMethodByString(token);
     else
-        ss.clear();
+        return PR_FAIL;
 
-    this->_body = this->_message.substr(ss.tellg());
-}
-
-//  TODO implement real behavior.
-//  Returns whether Request recieved end of header section or not.
-bool Request::isReady() const {
-    return true;
-}
-
-//  TODO Move to Request::initMethod().
-//  Convert from request method to Request::Method type.
-//  - Parameters
-//      method: reference of type Request::Method to write according to token.
-//      token: string to convert to Request::Method type.
-static void initMethod(Method& method, const std::string& token) {
-    if (token == "GET")
-        method = METHOD_GET;
-    else if (token == "POST")
-        method = METHOD_POST;
-    else if (token == "DELETE")
-        method = METHOD_DELETE;
+    if (iss >> token)
+        this->_target = token;
     else
-        assert(false);
+        return PR_FAIL;
+
+    if (iss >> token)
+        return parseHTTPVersion(token);
+    else
+        return PR_FAIL;
 }
 
-//  TODO Move to Request::initVersion().
-//  Convert HTTP to Request::Method type.
-//  - Parameters
-//      majorVersion: reference of type char to save HTTP major version.
-//      minorVersion: reference of type char to save HTTP minor version.
-//      token: HTTP version token to convert to majorVersion and minorVersion.
-static int initVersion(char& majorVersion, char& minorVersion, const std::string& token) {
+//  Parse HTTP version.
+//  - Parameters token: The string of HTTP version.
+//  - Return: Whether the parsing succeeded or not.
+ParsingResult Request::parseHTTPVersion(const std::string& token) {
     if (token.length() != 8)
-        return ERROR;
+        return PR_FAIL;
 
     if (token.substr(0, 5) != "HTTP/")
-        return ERROR;
+        return PR_FAIL;
 
     if (token[6] != '.')
-        return ERROR;
+        return PR_FAIL;
 
     if (!isdigit(token[5]) || !isdigit(token[7]))
-        return ERROR;
+        return PR_FAIL;
 
-    majorVersion = token[5];
-    minorVersion = token[7];
+    this->_majorVersion = token[5];
+    this->_minorVersion = token[7];
 
-    return NORMAL;
+    return PR_SUCCESS;
+}
+
+//  Parse HTTP message header field.
+//  - Parameters headerField: The string of header field.
+//  - Return: Whether the parsing succeeded or not.
+ParsingResult Request::parseHeader(const std::string& headerField) {
+    std::istringstream iss(headerField);
+    std::string name;
+    std::string value;
+
+    if (!std::getline(iss, name, ':'))
+        return PR_FAIL;
+    if (name[name.length() - 1] == ' ')
+        return PR_FAIL;
+    if (!std::getline(iss, value))
+        return PR_FAIL;
+
+    this->_headerSection.push_back(new HeaderSectionElementType(name, value));
+
+    return PR_SUCCESS;
+}
+
+//  Convert from request method to HTTP::RequestMethod type.
+//  - Parameters token: string to convert.
+//  - Return: The converted method value.
+HTTP::RequestMethod Request::requestMethodByString(const std::string& token) {
+    HTTP::RequestMethod method;
+
+    if (token == "GET")
+        method = HTTP::RM_GET;
+    else if (token == "POST")
+        method = HTTP::RM_POST;
+    else if (token == "DELETE")
+        method = HTTP::RM_DELETE;
+    else
+        method = HTTP::RM_UNKNOWN;
+
+    return method;
 }

--- a/Request.cpp
+++ b/Request.cpp
@@ -14,8 +14,8 @@ Request::~Request() {
 //  Returns first header field value of name.
 //  - Parameters name: The name to search value.
 //  - Return: The first header field value of name
-const std::string* Request::getFirstHeaderFieldValueByName(const std::string& name) {
-    for (HeaderSectionType::iterator iter = this->_headerSection.begin(); iter != this->_headerSection.end(); ++iter)
+const std::string* Request::getFirstHeaderFieldValueByName(const std::string& name) const {
+    for (HeaderSectionType::const_iterator iter = this->_headerSection.begin(); iter != this->_headerSection.end(); ++iter)
         if ((*iter)->first == name)
             return &(*iter)->second;
 
@@ -33,7 +33,7 @@ ReturnCaseOfRecv Request::receive(int clientSocketFD) {
         return RCRECV_ZERO;
 
     if (this->isReadyToProcess()) {
-        if (this->parseMessage() == PR_SUCCESS) // TODO Pass valid string to parseMessage and left remain string.
+        if (this->parseMessage() == PR_SUCCESS) //  TODO Pass valid string to parseMessage and left remain string.
             return RCRECV_PARSING_SUCCESS;
         else
             return RCRECV_PARSING_FAIL;

--- a/Request.hpp
+++ b/Request.hpp
@@ -1,50 +1,90 @@
 #ifndef REQUEST_HPP_
 #define REQUEST_HPP_
 
-#include <map>
 #include <string>
+#include <vector>
 
-typedef std::map<std::string, std::string> StringMap;
-
-enum Method {
-    METHOD_UNKNOWN,
-    METHOD_GET,
-    METHOD_POST,
-    METHOD_DELETE,
+//  ParsingResult indicates the result of parsing.
+enum ParsingResult {
+    PR_SUCCESS,
+    PR_FAIL,
 };
+
+namespace HTTP {
+
+//  RequestMethod indicates request method type of HTTP request message.
+enum RequestMethod {
+    RM_UNKNOWN,
+    RM_GET,
+    RM_POST,
+    RM_DELETE,
+};
+
+}   // namespace HTTP
+
+//  ReturnCaseOfRecv indicates the status of recv() call.
+//  - Constants
+//      RCRECV_ERROR: An error has occured.
+//      RCRECV_ZERO: Nothing received.
+//      RCRECV_SOME: Received some message but not enough to process.
+//      RCRECV_PARSING_FAIL: Received enough message to process, but failed parsing.
+//      RCRECV_PARSING_SUCCESS: Received enough message to process, and succeeded parsing.
+enum ReturnCaseOfRecv {
+    RCRECV_ERROR = -1,
+    RCRECV_ZERO,
+    RCRECV_SOME,
+    RCRECV_PARSING_FAIL,
+    RCRECV_PARSING_SUCCESS,
+};
+
+const int BUF_SIZE = 1024;
 
 //  Accumulate HTTP request message and parse it and store.
 //  - member variables
-//      _message: Accumulate HTTP request message.
+//      _message: Accumulated HTTP request message.
 //
 //      _method: Parsed request method.
 //      _target: Parsed target resource URI.
 //      _majorVersion: Parsed major version.
 //      _minorVersion: Parsed major version.
-//      _headerFieldMap: Parsed header field map.
+//      _headerSection: Parsed header field vector.
 //      _body: Parsed payload body.
 class Request {
 public:
-    Method getMethod() const { return this->_method; };
+    typedef std::pair<std::string, std::string> HeaderSectionElementType;
+    typedef std::vector<HeaderSectionElementType*> HeaderSectionType;
+
+    ~Request();
+
+    HTTP::RequestMethod getMethod() const { return this->_method; };
     char getMajorVersion() const { return this->_majorVersion; };
     char getMinorVersion() const { return this->_minorVersion; };
+    const std::string* getFirstHeaderFieldValueByName(const std::string& name);
 
-    void appendMessage(const std::string& str) { this->_message += str; };
-    void parse();
-
-    bool isReady() const;
+    ReturnCaseOfRecv receive(int clientSocketFD);
 
 private:
     std::string _message;
 
-    Method _method;
+    HTTP::RequestMethod _method;
     std::string _target;
     char _majorVersion;
     char _minorVersion;
 
-    StringMap _headerFieldMap;
+    HeaderSectionType _headerSection;
 
     std::string _body;
+
+    ssize_t receiveMessage(int clientSocketFD);
+    void appendMessage(const char* message);
+    bool isReadyToProcess() const;
+
+    ParsingResult parseMessage();
+    ParsingResult parseRequestLine(const std::string& requestLine);
+    ParsingResult parseHTTPVersion(const std::string& token);
+    ParsingResult parseHeader(const std::string& headerField);
+
+    HTTP::RequestMethod requestMethodByString(const std::string& token);
 };
 
 #endif  // REQUEST_HPP_

--- a/Request.hpp
+++ b/Request.hpp
@@ -59,7 +59,7 @@ public:
     HTTP::RequestMethod getMethod() const { return this->_method; };
     char getMajorVersion() const { return this->_majorVersion; };
     char getMinorVersion() const { return this->_minorVersion; };
-    const std::string* getFirstHeaderFieldValueByName(const std::string& name);
+    const std::string* getFirstHeaderFieldValueByName(const std::string& name) const;
 
     ReturnCaseOfRecv receive(int clientSocketFD);
 

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -40,7 +40,7 @@ private:
     std::size_t _clientMaxBodySize;
     std::vector<Location*> _location;
 
-    std::map<std::string, std::string> others;
+    std::map<std::string, std::string> _others;
 
     Connection* _connection;
 };


### PR DESCRIPTION
- Move recv() from Connection::receive() to Request::receive().
- Move TCP_MTU in Connection.hpp to BUF_SIZE in Request.hpp.
- Remove Connection::addReceivedLine().
- Create enum:
    - ParsingResult
    - RequestMethod
    - ReturnCaseOfRecv

## Description
Request 클래스를 confluence에서 저희가 정의한 개념과 일치하게 수정하였습니다.
리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다!

## Test
`make re && ./webserve conf/sample.conf` 테스트를 통과했습니다.