### PR TITLE
UNPQ 47 config 저장 형태 변경

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -53,13 +53,15 @@ void FTServer::initParseConfig(std::string filePath) {
                 sc = new VirtualServerConfig();
                 if (!sc->parsing(fs, ss, confLine)) // fstream, stringstream를 전달해주는 방식으로 진행
                     std::cerr << "not parsing config\n"; // 각 요소별 동적할당 해제시켜주는게 중요
-                ServerConfigKey *key = new ServerConfigKey;
+                ServerConfigKey key;
                 directiveContainer tConfigs = sc->getConfigs();
                 if (tConfigs.find("server_name") != tConfigs.end())
-                    key->_server_name = tConfigs.find("server_name")->second;
+                    key._server_name.push_back(tConfigs.find("server_name")->second[0]); // 가장 먼저 입력된 server_name 1개만
+                else
+                    key._server_name.push_back("localhost"); // server_name 비어있는 경우 localhost로 설정(안건)
                 if (tConfigs.find("listen") != tConfigs.end())
-                    key->_port = tConfigs.find("listen")->second[0]; // server_name이랑 port 갖고와서 _defaultconfig insert할 때 key로 넣어줘야함
-                this->_defaultConfigs.insert(std::pair<ServerConfigKey*, VirtualServerConfig *>(key, sc)); // map
+                    key._port = tConfigs.find("listen")->second[0]; // server_name이랑 port 갖고와서 _defaultconfig insert할 때 key로 넣어줘야함
+                this->_defaultConfigs.insert(std::pair<ServerConfigKey, VirtualServerConfig *>(key, sc)); // map
             } else
                 std::cerr << "not match (token != server)\n"; // (TODO) 오류터졌을 때 동적할당 해제 해줘야함
             ss.clear();

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -58,9 +58,14 @@ void FTServer::initParseConfig(std::string filePath) {
                 if (tConfigs.find("server_name") != tConfigs.end())
                     key._server_name.push_back(tConfigs.find("server_name")->second[0]); // 가장 먼저 입력된 server_name 1개만
                 else
-                    key._server_name.push_back("localhost"); // server_name 비어있는 경우 localhost로 설정(안건)
+                    key._server_name.push_back(""); // server_name 비어있는 경우 "" 설정(안건)
                 if (tConfigs.find("listen") != tConfigs.end())
                     key._port = tConfigs.find("listen")->second[0]; // server_name이랑 port 갖고와서 _defaultconfig insert할 때 key로 넣어줘야함
+                else {
+                    std::cerr << "not find listen value\n";
+                    delete sc;
+                    continue;
+                }
                 this->_defaultConfigs.insert(std::pair<ServerConfigKey, VirtualServerConfig *>(key, sc)); // map
             } else
                 std::cerr << "not match (token != server)\n"; // (TODO) 오류터졌을 때 동적할당 해제 해줘야함
@@ -99,32 +104,25 @@ VirtualServer*    FTServer::makeVirtualServer(VirtualServerConfig* virtualServer
     std::set<LocationConfig *> locs = virtualServerConf->getLocations();   // config per location block
 
     // server block
-    for (directiveContainer::iterator itr = config.begin(); itr != config.end(); itr++) {
-        std::cout << itr->first << " : ";
-        for (size_t i = 0; i < itr->second.size(); i++)
-            std::cout << itr->second[i] << " ";
-        std::cout << std::endl;
-    }
+    // for (directiveContainer::iterator itr = config.begin(); itr != config.end(); itr++) {
+    //     std::cout << itr->first << " : ";
+    //     for (size_t i = 0; i < itr->second.size(); i++)
+    //         std::cout << itr->second[i] << " ";
+    //     std::cout << std::endl;
+    // }
     // location block
-    for (std::set<LocationConfig *>::iterator itr = locs.begin(); itr != locs.end(); itr++) {
-        std::cout << "path : " << (*itr)->getPath() << std::endl;
-        directiveContainer tmp = (*itr)->getDirectives();
-        for (directiveContainer::iterator itr2 = tmp.begin(); itr2 != tmp.end(); itr2++) {
-            std::cout << itr2->first << " : ";
-            for (size_t i = 0; i < itr2->second.size(); i++)
-                std::cout << itr2->second[i] << " ";
-            std::cout << std::endl;
-        }
-    }
-    newVirtualServer = new VirtualServer(static_cast<in_port_t>(std::atoi(config["listen"].front().c_str())),
+    // for (std::set<LocationConfig *>::iterator itr = locs.begin(); itr != locs.end(); itr++) {
+    //     std::cout << "path : " << (*itr)->getPath() << std::endl;
+    //     directiveContainer tmp = (*itr)->getDirectives();
+    //     for (directiveContainer::iterator itr2 = tmp.begin(); itr2 != tmp.end(); itr2++) {
+    //         std::cout << itr2->first << " : ";
+    //         for (size_t i = 0; i < itr2->second.size(); i++)
+    //             std::cout << itr2->second[i] << " ";
+    //         std::cout << std::endl;
+    //     }
+    // }
+    newVirtualServer = new VirtualServer(static_cast<port_t>(std::atoi(config["listen"].front().c_str())),
                             config["server_name"].front());
-    // NODE how to runnig -> listen 127.0.0.1:80
-    // just port
-    // newVirtualServer->setPortNumber(static_cast<in_port_t>(std::atoi(config["listen"].front().c_str())));
-    
-    // Note single server_name
-    // newVirtualServer->setVirtualServerName(config["server_name"].front());
-    // newVirtualServer->setAddrStruct("127.0.0.1");
     return newVirtualServer;
 }
 

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -74,10 +74,50 @@ void FTServer::init() {
 }
 
 //  TODO Implement real behavior.
-//  Initialize all servers from server config set.
+//  Initialize all virtual servers from virtual server config set.
 void FTServer::initializeVirtualServers() {
-    VirtualServer* newVirtualServer = new VirtualServer(2000, "localhost");
-    this->_vVirtualServers.push_back(newVirtualServer);
+    //  VirtualServer* newVirtualServer = new VirtualServer("127.0.0.1", 2000, "localhost");
+    // NOTE only normal configs
+    for (VirtualServerConfigIter itr = this->_defaultConfigs.begin(); itr != this->_defaultConfigs.end(); itr++) {
+        VirtualServer* newVirtualServer = this->makeVirtualServer(*itr);
+        this->_vVirtualServers.push_back(newVirtualServer);
+    }
+}
+
+//  TODO Implement real one virtual server using config
+VirtualServer*    FTServer::makeVirtualServer(VirtualServerConfig* virtualServerConf) {
+    VirtualServer* newVirtualServer;
+    directiveContainer config = virtualServerConf->getConfigs();           // original config in server Block
+    std::set<LocationConfig *> locs = virtualServerConf->getLocations();   // config per location block
+
+    // server block
+    for (directiveContainer::iterator itr = config.begin(); itr != config.end(); itr++) {
+        std::cout << itr->first << " : ";
+        for (size_t i = 0; i < itr->second.size(); i++)
+            std::cout << itr->second[i] << " ";
+        std::cout << std::endl;
+    }
+    // location block
+    for (std::set<LocationConfig *>::iterator itr = locs.begin(); itr != locs.end(); itr++) {
+        std::cout << "path : " << (*itr)->getPath() << std::endl;
+        directiveContainer tmp = (*itr)->getDirectives();
+        for (directiveContainer::iterator itr2 = tmp.begin(); itr2 != tmp.end(); itr2++) {
+            std::cout << itr2->first << " : ";
+            for (size_t i = 0; i < itr2->second.size(); i++)
+                std::cout << itr2->second[i] << " ";
+            std::cout << std::endl;
+        }
+    }
+    newVirtualServer = new VirtualServer(static_cast<in_port_t>(std::atoi(config["listen"].front().c_str())),
+                            config["server_name"].front());
+    // NODE how to runnig -> listen 127.0.0.1:80
+    // just port
+    // newVirtualServer->setPortNumber(static_cast<in_port_t>(std::atoi(config["listen"].front().c_str())));
+    
+    // Note single server_name
+    // newVirtualServer->setVirtualServerName(config["server_name"].front());
+    // newVirtualServer->setAddrStruct("127.0.0.1");
+    return newVirtualServer;
 }
 
 void FTServer::initializeConnection(int ports[], int size) {

--- a/FTServer.hpp
+++ b/FTServer.hpp
@@ -46,6 +46,7 @@ private:
     typedef std::map<int, Connection*>           ConnectionMap;
     typedef std::map<int, Connection*>::iterator ConnectionMapIter;
     typedef std::set<VirtualServerConfig *>         VirtualServerConfigSet;
+    typedef std::set<VirtualServerConfig *>::iterator VirtualServerConfigIter;
 
     VirtualServerConfigSet _defaultConfigs;
     VirtualServerVec _vVirtualServers;
@@ -53,7 +54,7 @@ private:
     int _kqueue;
     bool _alive;
 
-    void makeVirtualServer(VirtualServerConfig* serverConf);
+    VirtualServer* makeVirtualServer(VirtualServerConfig* serverConf);
     void clientAccept(Connection* connection);
     void read(Connection* connection);
     void write(Connection* connection);

--- a/FTServer.hpp
+++ b/FTServer.hpp
@@ -52,22 +52,20 @@ public:
 private:
     struct compServer
     {
-        bool operator()(ServerConfigKey* lhs, ServerConfigKey* rhs) const
+        bool operator()(const ServerConfigKey& lhs, const ServerConfigKey& rhs) const
         {
-            return ((lhs->_port < rhs->_port) || (lhs->_server_name < rhs->_server_name));
+            return ((lhs._port < rhs._port) || (lhs._server_name < rhs._server_name));
         }
     };
     typedef std::vector<VirtualServer*>             VirtualServerVec;
     typedef std::map<int, Connection*>           ConnectionMap;
     typedef std::map<int, Connection*>::iterator ConnectionMapIter;
-    // typedef std::set<VirtualServerConfig *, compServer >   ServerConfigSet;
-    typedef std::map<ServerConfigKey *, VirtualServerConfig *, compServer >   ServerConfigMap;
-    // typedef std::set<VirtualServerConfig *>::iterator ServerConfigIter;
-    typedef std::map<ServerConfigKey *, VirtualServerConfig *, compServer >::iterator  ServerConfigIter;
+    typedef std::map<ServerConfigKey, VirtualServerConfig *, compServer >  VirtualServerConfigMap;
+    typedef std::map<ServerConfigKey, VirtualServerConfig *, compServer >::iterator  VirtualServerConfigIter;
 
-    ServerConfigMap _defaultConfigs;
-    VirtualServerVec       _vServers;
-    SocketMap       _mSocket;
+    VirtualServerConfigMap _defaultConfigs;
+    VirtualServerVec       _vVirtualServers;
+    ConnectionMap       _mConnection;
     int             _kqueue;
     bool            _alive;
 

--- a/FTServer.hpp
+++ b/FTServer.hpp
@@ -11,10 +11,18 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <utility>
 #include "Log.hpp"
 #include "VirtualServer.hpp"
 #include "Connection.hpp"
 #include "VirtualServerConfig.hpp"
+
+// NOTE port, server_name only one
+// vector<string>? for multiple server name
+struct ServerConfigKey {
+    std::string _port;
+    std::vector<std::string> _server_name;
+};
 
 // Manage multiple servers (like nginx)
 //  - TODO  
@@ -42,17 +50,26 @@ public:
     void run();
 
 private:
+    struct compServer
+    {
+        bool operator()(ServerConfigKey* lhs, ServerConfigKey* rhs) const
+        {
+            return ((lhs->_port < rhs->_port) || (lhs->_server_name < rhs->_server_name));
+        }
+    };
     typedef std::vector<VirtualServer*>             VirtualServerVec;
     typedef std::map<int, Connection*>           ConnectionMap;
     typedef std::map<int, Connection*>::iterator ConnectionMapIter;
-    typedef std::set<VirtualServerConfig *>         VirtualServerConfigSet;
-    typedef std::set<VirtualServerConfig *>::iterator VirtualServerConfigIter;
+    // typedef std::set<VirtualServerConfig *, compServer >   ServerConfigSet;
+    typedef std::map<ServerConfigKey *, VirtualServerConfig *, compServer >   ServerConfigMap;
+    // typedef std::set<VirtualServerConfig *>::iterator ServerConfigIter;
+    typedef std::map<ServerConfigKey *, VirtualServerConfig *, compServer >::iterator  ServerConfigIter;
 
-    VirtualServerConfigSet _defaultConfigs;
-    VirtualServerVec _vVirtualServers;
-    ConnectionMap _mConnection;
-    int _kqueue;
-    bool _alive;
+    ServerConfigMap _defaultConfigs;
+    VirtualServerVec       _vServers;
+    SocketMap       _mSocket;
+    int             _kqueue;
+    bool            _alive;
 
     VirtualServer* makeVirtualServer(VirtualServerConfig* serverConf);
     void clientAccept(Connection* connection);

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -1,12 +1,23 @@
 #include "VirtualServer.hpp"
 #include "Connection.hpp"
 
+//  Default constructor of VirtualServer.
+//  - Parameters(None)
+VirtualServer::VirtualServer() 
+: _portNumber(0),
+_name(""),
+_connection(nullptr)
+{
+}; 
+
 //  Constructor of VirtualServer.
 //  - Parameters
 //      portNumber: The port number.
 //      serverName: The server name.
 VirtualServer::VirtualServer(short portNumber, const std::string& name)
-: _portNumber(portNumber), _name(name) { }
+: _portNumber(portNumber), _name(name) {
+    _connection = nullptr;
+}
 
 //  Process request from client.
 //  - Parameters

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -27,9 +27,14 @@ typedef unsigned short port_t;
 //      _connection: The connection to accept client for this server.
 class VirtualServer {
 public:
+    VirtualServer();
     VirtualServer(short portNumber, const std::string& name);
 
-    in_port_t getPortNumber() const { return this->_portNumber; };
+    port_t getPortNumber() const { return this->_portNumber; }
+    std::string getServerName() const { return this->_name; }
+    void setPortNumber(port_t portNumber) { this->_portNumber = portNumber; }
+    void setServerName(std::string serverName) { this->_name = serverName; }
+
     void setConnection(Connection* connection) { this->_connection = connection; };
 
     void process(Connection& clientConnection, int kqueueFD) const;

--- a/VirtualServerConfig.hpp
+++ b/VirtualServerConfig.hpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include "LocationConfig.hpp"
 
+typedef std::map<std::string, std::vector<std::string> > directiveContainer;
 //  Virtual server config block (parsed config file)
 //  - Member variables
 //      _inBrace: To check if it's inside server block 

--- a/conf/sample.conf
+++ b/conf/sample.conf
@@ -1,5 +1,5 @@
 server {
-    listen :80;
+    listen 80;
     server_name google.com www.google.com;
     root /var/www/html;
 
@@ -15,8 +15,7 @@ server {
 }
 
 server {
-	listen 127.0.0.1:443;
-	listen [::]:443;
+	listen 443;
 
 	ssl on;
 	ssl_certificate /etc/ssl/certs/localhost.dev.crt;

--- a/conf/sample.conf
+++ b/conf/sample.conf
@@ -13,6 +13,21 @@ server {
     }
     return 301 https://www.google.com;
 }
+server {
+    listen 80;
+    server_name google.com www.google2.com;
+    root /var/www/html;
+
+    location / {
+        autoindex on;
+        index   index.html index.htm;
+    }
+    location /post {
+        root   html;
+        client_max_body_size 10m;
+    }
+    return 301 https://www.google.com;
+}
 
 server {
 	listen 443;


### PR DESCRIPTION
# Description

- map<struct, serverConfig*, cmp>타입으로 변경 완료. key는 port, server_name을 각 1개씩만 갖도록 구성
- making virtualServer by serverConfig

# Test

make re && ./webserve conf/sample.conf 테스트 통과완료했습니다.