### PR TITLE
UNPQ-62 fix: remove OWS in request header field value

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -230,10 +230,10 @@ void FTServer::read(Connection* connection) {
 VirtualServer& FTServer::getTargetVirtualServer(Connection& clientConnection) {
     //  TODO Implement real behavior. Change the return type from reference to pointer type.
     int cntVirtualServers = this->_vVirtualServers.size();
-    const std::string* a = clientConnection.getRequest().getFirstHeaderFieldValueByName("Host");
+    const std::string* tHostName = clientConnection.getRequest().getFirstHeaderFieldValueByName("Host");
     for (int i = 0; i < cntVirtualServers; i++) {
         if ((this->_vVirtualServers[i]->getPortNumber() == clientConnection.getPort()) &&
-            (this->_vVirtualServers[i]->getServerName() == *a))
+            (this->_vVirtualServers[i]->getServerName() == *tHostName))
             return *this->_vVirtualServers[i];
     }
     return *this->_defaultVirtualServers[clientConnection.getPort()];

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -233,7 +233,7 @@ VirtualServer& FTServer::getTargetVirtualServer(Connection& clientConnection) {
     const std::string* a = clientConnection.getRequest().getFirstHeaderFieldValueByName("Host");
     for (int i = 0; i < cntVirtualServers; i++) {
         if ((this->_vVirtualServers[i]->getPortNumber() == clientConnection.getPort()) &&
-            (this->_vVirtualServers[i]->getServerName() == (*a).substr(1, std::string::npos))) // TODO compare strings
+            (this->_vVirtualServers[i]->getServerName() == *a))
             return *this->_vVirtualServers[i];
     }
     return *this->_defaultVirtualServers[clientConnection.getPort()];

--- a/Request.cpp
+++ b/Request.cpp
@@ -155,13 +155,21 @@ ParsingResult Request::parseHeader(const std::string& headerField) {
     std::istringstream iss(headerField);
     std::string name;
     std::string value;
+    char ch;
 
     if (!std::getline(iss, name, ':'))
         return PR_FAIL;
     if (name[name.length() - 1] == ' ')
         return PR_FAIL;
+    if (!iss.get(ch))
+        return PR_FAIL;
+    if (!(ch == '\x09' || ch == ' '))
+        iss.putback(ch);
     if (!std::getline(iss, value))
         return PR_FAIL;
+    ch = value[value.length() - 1];
+    if (ch == '\x09' || ch == ' ')
+        value.erase(value.length() - 1);
 
     this->_headerSection.push_back(new HeaderSectionElementType(name, value));
 


### PR DESCRIPTION
## Description

요청의 헤더 필드 값의 앞 뒤 공백을 제거하였습니다.
앞 뒤 공백의 기준은 \[[RFC7230.3.2.](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2)\]를 따랐습니다.

## Test

make re && ./webserve conf/sample.conf 테스트를 통과했습니다.
FTServer::getTargetVirtualServer() 함수에서 정상적으로 Host 헤더 필드의 값에 맞는 virtualServer를 반환하는 것을 확인했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂