### PR TITLE
UNPQ-63 feat: implement lite version of directory listing

### DIFF
--- a/Location.hpp
+++ b/Location.hpp
@@ -24,9 +24,9 @@ public:
     void getRepresentationPath(const std::string& resourceURI, std::string& representationPath) const;
 
     std::string getRoute() { return this->_route; };
-    std::string getRoot() { return this->_root; };
-    std::string getIndex() { return this->_index; };
-    bool getAutoIndex() { return this->_autoindex; };
+    std::string getRoot() const { return this->_root; };
+    std::string getIndex() const { return this->_index; };
+    bool getAutoIndex() const { return this->_autoindex; };
     char getAllowedHTTPMethod() { return this->_allowedHTTPMethod; };
     std::vector<std::string> getCGIExtention() { return this->_cgiExtension; }
 

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -1,6 +1,8 @@
 #include <fstream>
-#include <cstdio>
+#include <sstream>
 #include <cstring>
+#include <sys/stat.h>
+#include <dirent.h>
 #include "VirtualServer.hpp"
 #include "Connection.hpp"
 #include "constant.hpp"
@@ -66,76 +68,162 @@ VirtualServer::ReturnCode VirtualServer::processRequest(Connection& clientConnec
     return VirtualServer::RC_SUCCESS;
 }
 
+//  Process GET request.
+//  - Parameters request: The request to process.
+//  - Return(None)
 int VirtualServer::processGET(Connection& clientConnection) {
     const Request& request = clientConnection.getRequest();
     const std::string& targetResourceURI = request.getTargetResourceURI();
+    struct stat buf;
+    std::string targetRepresentationURI;
 
-    for (std::vector<Location*>::const_iterator iter = this->_location.begin(); iter != this->_location.end(); ++iter) {
+    std::vector<Location*>::const_iterator iter;
+    for (iter = this->_location.begin(); iter != this->_location.end(); ++iter) {
         const Location& location = **iter;
 
-        if (location.isRouteMatch(targetResourceURI)) {
-            if (!location.isRequestMethodAllowed(request.getMethod())) {
-                this->set405Response(clientConnection);
-                return 0;
-            }
+        if (!location.isRouteMatch(targetResourceURI))
+            continue;
 
-            this->set404Response(clientConnection); // TODO 강제로 404 만드는 임시 코드
-            return 0;   // TODO 임시 코드
+        location.getRepresentationPath(targetResourceURI, targetRepresentationURI);
+        if (stat(targetRepresentationURI.c_str(), &buf) == 0
+                && (buf.st_mode & S_IFDIR) != 0) {
+            if (!location.isRequestMethodAllowed(request.getMethod()))
+                return this->set405Response(clientConnection);
 
-            const std::string& targetResourceURI = request.getTargetResourceURI();
-            location.getRepresentationPath(targetResourceURI, this->_targetRepresentationURI);
-            // TODO 만약 _targetRepresentationURI가 존재하는 파일이라면 상태를 200으로 설정
-            // TODO (추측) 만약 _targetRepresentationURI가 존재하지 않는 파일일 경우 index에 정의된 파일로 설정하기. 그것도 없으면 404.(index 관련 로직 조사 필요 POST라면? DELETE라면?)
-            break;
+            this->setStatusLine(clientConnection, Status::I_200);
+
+            // TODO 적절한 헤더 필드 추가하기(content-length)
+            clientConnection.appendResponseMessage("Date: ");
+            clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+            clientConnection.appendResponseMessage("\r\n\r\n");
+
+            std::ifstream targetRepresentation(targetRepresentationURI, std::ios_base::binary | std::ios_base::ate);
+            if (!targetRepresentation.is_open())
+                return -1;
+
+            std::ifstream::pos_type size = targetRepresentation.tellg();
+            std::string str(size, '\0');
+            targetRepresentation.seekg(0);
+            if (targetRepresentation.read(&str[0], size))
+                clientConnection.appendResponseMessage(str.c_str());
+
+            targetRepresentation.close();
+
+            return 0;
         }
+
+        if (stat(location.getIndex().c_str(), &buf) == 0
+                && (buf.st_mode & S_IFDIR) != 0) {
+            this->setStatusLine(clientConnection, Status::I_200);
+
+            // TODO 적절한 헤더 필드 추가하기(content-length)
+            clientConnection.appendResponseMessage("Date: ");
+            clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+            clientConnection.appendResponseMessage("\r\n\r\n");
+
+            std::ifstream targetRepresentation(location.getIndex(), std::ios_base::binary | std::ios_base::ate);
+            if (!targetRepresentation.is_open())
+                return -1;
+
+            std::ifstream::pos_type size = targetRepresentation.tellg();
+            std::string str(size, '\0');
+            targetRepresentation.seekg(0);
+            if (targetRepresentation.read(&str[0], size))
+                clientConnection.appendResponseMessage(str.c_str());
+
+            targetRepresentation.close();
+
+            return 0;
+        }
+
+        if (location.getAutoIndex())
+            return this->setListResponse(clientConnection, location.getRoot());
     }
 
-    this->setStatusLine(clientConnection, Status::I_200);
-
-    // TODO 적절한 헤더 필드 추가하기(content-length)
-    clientConnection.appendResponseMessage("Date: ");
-    clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
-    clientConnection.appendResponseMessage("\r\n\r\n");
-
-    std::ifstream targetRepresentation(this->_targetRepresentationURI, std::ios_base::binary | std::ios_base::ate);
-    if (!targetRepresentation.is_open())
-        return -1;
-
-    std::ifstream::pos_type size = targetRepresentation.tellg();
-    std::string str(size, '\0');
-    targetRepresentation.seekg(0);
-    if (targetRepresentation.read(&str[0], size))
-        clientConnection.appendResponseMessage(str.c_str());
-
-    return 0;
+    return this->set404Response(clientConnection);
 }
 
-//  Process POST request's unique work.
-//  If the request method is not POST, do nothing.
+//  Process POST request.
 //  - Parameters request: The request to process.
 //  - Return(None)
 int VirtualServer::processPOST(Connection& clientConnection) {
-    // TODO implement
-    std::ofstream out(this->_targetRepresentationURI.c_str());
-    if (!out.is_open())
-        return -1;
+    const Request& request = clientConnection.getRequest();
+    const std::string& targetResourceURI = request.getTargetResourceURI();
+    std::string targetRepresentationURI;
 
-    const std::string& requestBody = clientConnection.getRequest().getBody();
-    out << requestBody;
-    out.close();
+    std::vector<Location*>::const_iterator iter;
+    for (iter = this->_location.begin(); iter != this->_location.end(); ++iter) {
+        const Location& location = **iter;
 
-    return 0;
+        if (!location.isRouteMatch(targetResourceURI))
+            continue;
+
+        location.getRepresentationPath(targetResourceURI, targetRepresentationURI);
+        if (!location.isRequestMethodAllowed(request.getMethod()))
+            return this->set405Response(clientConnection);
+
+        std::ofstream out(targetRepresentationURI.c_str());
+        if (!out.is_open())
+            return -1;
+
+        const std::string& requestBody = clientConnection.getRequest().getBody();
+        out << requestBody;
+        out.close();
+
+        this->setStatusLine(clientConnection, Status::I_200);
+
+        // TODO 적절한 헤더 필드 추가하기(content-length)
+        clientConnection.appendResponseMessage("Date: ");
+        clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+        clientConnection.appendResponseMessage("\r\n\r\n");
+
+        // TODO 적절한 바디 생성하기
+
+        return 0;
+    }
+
+    return this->set405Response(clientConnection);
 }
 
-//  Process DELETE request's unique work.
-//  If the request method is not DELETE, do nothing.
+//  Process DELETE request.
 //  - Parameters request: The request to process.
 //  - Return(None)
 int VirtualServer::processDELETE(Connection& clientConnection) {
-    // TODO implement
-    unlink(this->_targetRepresentationURI.c_str());
+    const Request& request = clientConnection.getRequest();
+    const std::string& targetResourceURI = request.getTargetResourceURI();
+    struct stat buf;
+    std::string targetRepresentationURI;
 
-    return 0;
+    std::vector<Location*>::const_iterator iter;
+    for (iter = this->_location.begin(); iter != this->_location.end(); ++iter) {
+        const Location& location = **iter;
+
+        if (!location.isRouteMatch(targetResourceURI))
+            continue;
+
+        location.getRepresentationPath(targetResourceURI, targetRepresentationURI);
+        if (stat(targetRepresentationURI.c_str(), &buf) == 0
+                && (buf.st_mode & S_IFDIR) != 0) {
+            if (!location.isRequestMethodAllowed(request.getMethod()))
+                return this->set405Response(clientConnection);
+
+            if (unlink(targetRepresentationURI.c_str()) == -1)
+                return this->set500Response(clientConnection);
+
+            this->setStatusLine(clientConnection, Status::I_200);
+
+            // TODO 적절한 헤더 필드 추가하기(content-length)
+            clientConnection.appendResponseMessage("Date: ");
+            clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+            clientConnection.appendResponseMessage("\r\n\r\n");
+
+            // TODO 적절한 바디 설정하기
+
+            return 0;
+        }
+    }
+
+    return this->set404Response(clientConnection);
 }
 
 //  Set status line to response of clientConnection.
@@ -151,7 +239,7 @@ void VirtualServer::setStatusLine(Connection& clientConnection, Status::Index in
 //  set response message with 404 status.
 //  - Parameters clientConnection: The client connection.
 //  - Return(None)
-void VirtualServer::set404Response(Connection& clientConnection) {
+int VirtualServer::set404Response(Connection& clientConnection) {
     clientConnection.clearResponseMessage();
     this->setStatusLine(clientConnection, Status::I_404);
 
@@ -159,12 +247,14 @@ void VirtualServer::set404Response(Connection& clientConnection) {
     clientConnection.appendResponseMessage("Date: ");
     clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
     clientConnection.appendResponseMessage("\r\n\r\n");
+
+    return 0;
 }
 
 //  set response message with 405 status.
 //  - Parameters clientConnection: The client connection.
 //  - Return(None)
-void VirtualServer::set405Response(Connection& clientConnection) {
+int VirtualServer::set405Response(Connection& clientConnection) {
     clientConnection.clearResponseMessage();
     this->setStatusLine(clientConnection, Status::I_405);
 
@@ -172,17 +262,55 @@ void VirtualServer::set405Response(Connection& clientConnection) {
     clientConnection.appendResponseMessage("Date: ");
     clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
     clientConnection.appendResponseMessage("\r\n\r\n");
+
+    return 0;
 }
 
 //  set response message with 500 status.
 //  - Parameters clientConnection: The client connection.
 //  - Return(None)
-void VirtualServer::set500Response(Connection& clientConnection) {
+int VirtualServer::set500Response(Connection& clientConnection) {
     clientConnection.clearResponseMessage();
     this->setStatusLine(clientConnection, Status::I_500);
-    //
+
     // TODO append header section and body
     clientConnection.appendResponseMessage("Date: ");
     clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
     clientConnection.appendResponseMessage("\r\n\r\n");
+
+    return 0;
+}
+
+int VirtualServer::setListResponse(Connection& clientConnection, const std::string& path) {
+    clientConnection.clearResponseMessage();
+    this->setStatusLine(clientConnection, Status::I_200);
+
+    // TODO 필요에 따라 헤더 추가하기
+    clientConnection.appendResponseMessage("Transfer-Encoding: chunked\r\n");
+    clientConnection.appendResponseMessage("Content-Type: text/plain");
+    clientConnection.appendResponseMessage("Date: ");
+    clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+    clientConnection.appendResponseMessage("\r\n\r\n");
+
+    DIR* dir = opendir(path.c_str());
+    if (dir == NULL)
+        return -1;
+
+    while (true) {
+        const struct dirent* entry = readdir(dir);
+        if (entry == NULL)
+            break;
+
+        std::stringstream iss;
+        iss << entry->d_namlen + 1;
+        clientConnection.appendResponseMessage(iss.str().c_str());
+        clientConnection.appendResponseMessage("\r\n");
+        clientConnection.appendResponseMessage(entry->d_name);
+        clientConnection.appendResponseMessage("\n\r\n");
+    }
+    clientConnection.appendResponseMessage("0\r\n\r\n");
+
+    closedir(dir);
+
+    return 0;
 }

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -21,7 +21,6 @@ const Status Status::_array[] = {
     { "411", "length required" },
     { "413", "payload too large" },
     { "500", "internal server error" },
-    { "505", "http version not supported" },
 };
 
 //  Default constructor of VirtualServer.

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -83,12 +83,12 @@ int VirtualServer::processGET(Connection& clientConnection) {
         if (!location.isRouteMatch(targetResourceURI))
             continue;
 
+        if (!location.isRequestMethodAllowed(request.getMethod()))
+            return this->set405Response(clientConnection);
+
         location.getRepresentationPath(targetResourceURI, targetRepresentationURI);
         if (stat(targetRepresentationURI.c_str(), &buf) == 0
                 && (buf.st_mode & S_IFDIR) != 0) {
-            if (!location.isRequestMethodAllowed(request.getMethod()))
-                return this->set405Response(clientConnection);
-
             this->setStatusLine(clientConnection, Status::I_200);
 
             // TODO 적절한 헤더 필드 추가하기(content-length)

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -35,7 +35,6 @@ struct Status {
         I_411,
         I_413,
         I_500,
-        I_505,
     };
 
     static const Status _array[];

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -72,7 +72,6 @@ inline const char* getStatusReasonBy(HTTP::Status::Index index) {
 //          std::string _defaultErrorPagePath: The path used to set error pages.
 //
 //      _statusCode: Store status code of server.
-//      _targetRepresentationURI: Store target representation URI.
 class VirtualServer {
 public:
     enum ReturnCode {
@@ -102,17 +101,16 @@ private:
 
     std::map<std::string, std::string> _others;
 
-    std::string _targetRepresentationURI;
-
     int processGET(Connection& clientConnection);
     int processPOST(Connection& clientConnection);
     int processDELETE(Connection& clientConnection);
 
     void setStatusLine(Connection& clientConnection, HTTP::Status::Index index);
 
-    void set404Response(Connection& clientConnection);
-    void set405Response(Connection& clientConnection);
-    void set500Response(Connection& clientConnection);
+    int set404Response(Connection& clientConnection);
+    int set405Response(Connection& clientConnection);
+    int set500Response(Connection& clientConnection);
+    int setListResponse(Connection& clientConnection, const std::string& path);
 };  // VirtualServer
 
 #endif  // VIRTUALSERVER_HPP_


### PR DESCRIPTION
- implement lite version of GET, POST, DELETE
- implement lite version of directory listing

## Description

GET, POST, DELETE의 간단한 버전 구현
간단한 버전의 directory listing 구현

## Issue
directory listing을 크롬으로 전달받아보려 했으나,
location의 root가 설정 파일이 설정되지 않고 ""로 설정되어 직접 location의 root에 값을 넣어 테스트하는 방식을 모색 중

현재는 root에 의도한 값이 들어가지 않아 로컬의 경로를 제대로 계산하지 못합니다.
동시에 autoindex를 하려고 할 때 root 안의 파일들을 출력하는데, root 경로를 제대로 계산하지 못해서 500 상태 코드 응답을 반환하고 있습니다.

## Test

make re && ./webserve conf/sample.conf 테스트를 통과했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂