### PR TITLE
UNPQ-57 feat: implement header field of GET response

### DIFF
--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -23,6 +23,9 @@ const Status Status::_array[] = {
     { "500", "internal server error" },
 };
 
+static void getContentType(const std::string& name, std::string& type);
+static void getExtension(const std::string& name, std::string& extension);
+
 //  Default constructor of VirtualServer.
 //  - Parameters(None)
 VirtualServer::VirtualServer() 
@@ -91,10 +94,29 @@ int VirtualServer::processGET(Connection& clientConnection) {
                 && (buf.st_mode & S_IFREG) != 0) {
             this->setStatusLine(clientConnection, Status::I_200);
 
-            // TODO 적절한 헤더 필드 추가하기(content-length)
+            clientConnection.appendResponseMessage("Server: crash-webserve\r\n");
             clientConnection.appendResponseMessage("Date: ");
             clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
-            clientConnection.appendResponseMessage("\r\n\r\n");
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Content-Type: ");
+            std::string type;
+            getContentType(targetRepresentationURI, type);
+            clientConnection.appendResponseMessage(type);
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Content-Length: ");
+            std::ostringstream oss;
+            oss << buf.st_size;
+            clientConnection.appendResponseMessage(oss.str().c_str());
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Last-Modified: ");
+            const struct timespec lastModified = buf.st_mtimespec;
+            const struct tm tm = *gmtime(&lastModified.tv_sec);
+            char lastModifiedString[BUF_SIZE];
+            strftime(lastModifiedString, BUF_SIZE, "%a, %d %b %Y %H:%M:%S GMT", &tm);
+            clientConnection.appendResponseMessage(lastModifiedString);
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Connection: keep-alive\r\n");
+            clientConnection.appendResponseMessage("\r\n");
 
             std::ifstream targetRepresentation(targetRepresentationURI, std::ios_base::binary | std::ios_base::ate);
             if (!targetRepresentation.is_open())
@@ -115,10 +137,29 @@ int VirtualServer::processGET(Connection& clientConnection) {
                 && (buf.st_mode & S_IFREG) != 0) {
             this->setStatusLine(clientConnection, Status::I_200);
 
-            // TODO 적절한 헤더 필드 추가하기(content-length)
+            clientConnection.appendResponseMessage("Server: crash-webserve\r\n");
             clientConnection.appendResponseMessage("Date: ");
             clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
-            clientConnection.appendResponseMessage("\r\n\r\n");
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Content-Type: ");
+            std::string type;
+            getContentType(targetRepresentationURI, type);
+            clientConnection.appendResponseMessage(type);
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Content-Length: ");
+            std::ostringstream oss;
+            oss << buf.st_size;
+            clientConnection.appendResponseMessage(oss.str().c_str());
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Last-Modified: ");
+            const struct timespec lastModified = buf.st_mtimespec;
+            const struct tm tm = *gmtime(&lastModified.tv_sec);
+            char lastModifiedString[BUF_SIZE];
+            strftime(lastModifiedString, BUF_SIZE, "%a, %d %b %Y %H:%M:%S GMT", &tm);
+            clientConnection.appendResponseMessage(lastModifiedString);
+            clientConnection.appendResponseMessage("\r\n");
+            clientConnection.appendResponseMessage("Connection: keep-alive\r\n");
+            clientConnection.appendResponseMessage("\r\n");
 
             std::ifstream targetRepresentation(location.getIndex(), std::ios_base::binary | std::ios_base::ate);
             if (!targetRepresentation.is_open())
@@ -356,4 +397,34 @@ int VirtualServer::setListResponse(Connection& clientConnection, const std::stri
     clientConnection.appendResponseMessage("</pre><hr></body></html>");
 
     return 0;
+}
+
+//  set 'type' of 'name'
+//  - Parameters
+//      name: name of file
+//      type: type to set
+//  - Return(None)
+static void getContentType(const std::string& name, std::string& type) {
+    std::string extension;
+    getExtension(name, extension);
+    if (std::strcmp(extension.c_str(), "txt") == 0)
+        type = "text/plain";
+    else if (std::strcmp(extension.c_str(), "html") == 0)
+        type = "text/html";
+    else
+        type = "application/octet-stream";
+}
+
+//  set 'extension' of 'name'
+//  - Parameters
+//      name: name of file
+//      type: type to set
+//  - Return(None)
+static void getExtension(const std::string& name, std::string& extension) {
+    const std::string::size_type extensionBeginPosition = name.rfind('.') + 1;
+    extension.clear();
+    if (extensionBeginPosition !=  std::string::npos)
+        extension = name.c_str() + extensionBeginPosition;
+    else
+        return;
 }

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -23,8 +23,8 @@ const Status Status::_array[] = {
     { "500", "internal server error" },
 };
 
-static void getContentType(const std::string& name, std::string& type);
-static void getExtension(const std::string& name, std::string& extension);
+static void updateContentType(const std::string& name, std::string& type);
+static void updateExtension(const std::string& name, std::string& extension);
 
 //  Default constructor of VirtualServer.
 //  - Parameters(None)
@@ -100,7 +100,7 @@ int VirtualServer::processGET(Connection& clientConnection) {
             clientConnection.appendResponseMessage("\r\n");
             clientConnection.appendResponseMessage("Content-Type: ");
             std::string type;
-            getContentType(targetRepresentationURI, type);
+            updateContentType(targetRepresentationURI, type);
             clientConnection.appendResponseMessage(type);
             clientConnection.appendResponseMessage("\r\n");
             clientConnection.appendResponseMessage("Content-Length: ");
@@ -143,7 +143,7 @@ int VirtualServer::processGET(Connection& clientConnection) {
             clientConnection.appendResponseMessage("\r\n");
             clientConnection.appendResponseMessage("Content-Type: ");
             std::string type;
-            getContentType(targetRepresentationURI, type);
+            updateContentType(targetRepresentationURI, type);
             clientConnection.appendResponseMessage(type);
             clientConnection.appendResponseMessage("\r\n");
             clientConnection.appendResponseMessage("Content-Length: ");
@@ -404,9 +404,9 @@ int VirtualServer::setListResponse(Connection& clientConnection, const std::stri
 //      name: name of file
 //      type: type to set
 //  - Return(None)
-static void getContentType(const std::string& name, std::string& type) {
+static void updateContentType(const std::string& name, std::string& type) {
     std::string extension;
-    getExtension(name, extension);
+    updateExtension(name, extension);
     if (std::strcmp(extension.c_str(), "txt") == 0)
         type = "text/plain";
     else if (std::strcmp(extension.c_str(), "html") == 0)
@@ -420,7 +420,7 @@ static void getContentType(const std::string& name, std::string& type) {
 //      name: name of file
 //      type: type to set
 //  - Return(None)
-static void getExtension(const std::string& name, std::string& extension) {
+static void updateExtension(const std::string& name, std::string& extension) {
     const std::string::size_type extensionBeginPosition = name.rfind('.') + 1;
     extension.clear();
     if (extensionBeginPosition !=  std::string::npos)


### PR DESCRIPTION
- implement header field of GET response
	- Content-Type
	- Content-Length
	- Last-Modified
	- Connection

## Description

GET 요청에 대한 응답의 헤더 필드 구현
- Content-Type
- Content-Length
- Last-Modified
- Connection

## Test

make re && ./webserve conf/sample.conf 테스트를 통과했습니다.
`.txt`과 `.html` 확장자를 가진 파일이 정상적으로 출력됨을 확인했습니다.
그 외의 확장자는 `application/octet-stream` 로 처리하며, chrome에서는 파일을 다운로드 하는 동작을 하는 것을 확인했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂