### PR TITLE
UNPQ-57 feat : implement header field

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -146,7 +146,7 @@ VirtualServer*    FTServer::makeVirtualServer(VirtualServerConfig* virtualServer
             else if (!itr2->first.compare("index")) {
                 newLocation->setIndex(itr2->second);
             }
-            else if (!itr2->first.compare("limit_except")) {
+            else if (!itr2->first.compare("allow_method")) {
                 newLocation->setAllowedHTTPMethod(itr2->second); 
             }
             else if (!itr2->first.compare("cgi")) {

--- a/Location.hpp
+++ b/Location.hpp
@@ -37,8 +37,16 @@ public:
     };
     void setAutoIndex(bool isAutoindex) { this->_autoindex = isAutoindex; };
     void setAllowedHTTPMethod(std::vector<std::string> allowedMethod) {
-        if (allowedMethod[0] == "GET")
-            this->_allowedHTTPMethod |= HTTP::RM_GET; // TODO multiple method, check RM_GET name
+        if (allowedMethod.size() == 0)
+            this->_allowedHTTPMethod = 7;
+        for (std::vector<std::string>::const_iterator itr = allowedMethod.begin(); itr != allowedMethod.end(); itr++) {
+            if (*itr == "GET")
+                this->_allowedHTTPMethod |= HTTP::RM_GET;
+            else if (*itr == "POST")
+                this->_allowedHTTPMethod |= HTTP::RM_POST; 
+            else if (*itr == "DELETE")
+                this->_allowedHTTPMethod |= HTTP::RM_DELETE;
+        }
     };
     void setCGIExtention(std::vector<std::string> cgiExt) { this->_cgiExtension = cgiExt; }
     void setOtherDirective(std::string directiveName, std::vector<std::string> directiveValue) { 
@@ -67,7 +75,7 @@ inline bool Location::isRouteMatch(const std::string& resourceURI) const {
 //  - Parameters requestMethod: request method of request.
 //  - Return: whether the 'requestMethod' is allowed in this location.
 inline bool Location::isRequestMethodAllowed(HTTP::RequestMethod requestMethod) const {
-    return (this->_allowedHTTPMethod | requestMethod) != 0;
+    return (this->_allowedHTTPMethod & requestMethod);
 }
 
 #endif  // LOCATION_HPP_

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -107,7 +107,7 @@ private:
     void setStatusLine(Connection& clientConnection, HTTP::Status::Index index);
 
     int set404Response(Connection& clientConnection);
-    int set405Response(Connection& clientConnection);
+    int set405Response(Connection& clientConnection, const Location* locations);
     int set500Response(Connection& clientConnection);
     int setListResponse(Connection& clientConnection, const std::string& path);
 };  // VirtualServer


### PR DESCRIPTION
# Description
- Allow 헤더필드 구현
- (hotfix) config에서 헤더필드 1개만 갖고오도록 한 부분 수정

# Test
- make re && webserve ./conf/sample.conf 클리어
- 단, limit_except를 location에 넣어주셔야 합니다. conf 내용을 확인하고 실행해주세요