### PR TITLE
UNPQ-57 move makeHeaderField method

### DIFF
--- a/Connection.cpp
+++ b/Connection.cpp
@@ -165,28 +165,6 @@ void Connection::dispose() {
     this->addKeventOneshot(kqueue, 0);
 }
 
-std::string Connection::makeHeaderField(unsigned short fieldName) {
-    switch (fieldName)
-    {
-    case HTTP::DATE:
-        return makeDateHeaderField();
-    }
-    return ""; // TODO delete
-}
-
-// Find the current time based on GMT
-//  - Parameters(None)
-//  - Return
-//      Current time based on GMT(std::string)
-std::string Connection::makeDateHeaderField() {
-    char cDate[1000];
-    time_t rr = time(0);
-    struct tm tm = *gmtime(&rr);
-    strftime(cDate, sizeof(cDate), "%a, %d %b %Y %H:%M:%S GMT", &tm);
-    std::string dateStr = cDate;
-    return dateStr;
-}
-
 // Creates new Connection and set for the attribute.
 //  - Return(none)
 void Connection::newSocket() {

--- a/Connection.hpp
+++ b/Connection.hpp
@@ -71,9 +71,6 @@ public:
     void clearResponseMessage();
     void appendResponseMessage(const std::string& message);
 
-    std::string makeHeaderField(unsigned short fieldName);
-    std::string makeDateHeaderField();
-
 private:
     bool _client;
     int _ident;

--- a/Location.cpp
+++ b/Location.cpp
@@ -5,7 +5,7 @@ _route(""),
 _root(""),
 _index(""),
 _autoindex(false),
-_allowedHTTPMethod(0)
+_allowedHTTPMethod(7)
 {
 }
 

--- a/Location.hpp
+++ b/Location.hpp
@@ -37,16 +37,17 @@ public:
     };
     void setAutoIndex(bool isAutoindex) { this->_autoindex = isAutoindex; };
     void setAllowedHTTPMethod(std::vector<std::string> allowedMethod) {
-        if (allowedMethod.size() == 0)
-            this->_allowedHTTPMethod = 7;
+        char beAllowed = '0';
         for (std::vector<std::string>::const_iterator itr = allowedMethod.begin(); itr != allowedMethod.end(); itr++) {
             if (*itr == "GET")
-                this->_allowedHTTPMethod |= HTTP::RM_GET;
+                beAllowed |= HTTP::RM_GET;
             else if (*itr == "POST")
-                this->_allowedHTTPMethod |= HTTP::RM_POST; 
+                beAllowed |= HTTP::RM_POST; 
             else if (*itr == "DELETE")
-                this->_allowedHTTPMethod |= HTTP::RM_DELETE;
+                beAllowed |= HTTP::RM_DELETE;
         }
+        if (beAllowed)
+            this->_allowedHTTPMethod = beAllowed;
     };
     void setCGIExtention(std::vector<std::string> cgiExt) { this->_cgiExtension = cgiExt; }
     void setOtherDirective(std::string directiveName, std::vector<std::string> directiveValue) { 

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -93,7 +93,7 @@ int VirtualServer::processGET(Connection& clientConnection) {
 
             // TODO 적절한 헤더 필드 추가하기(content-length)
             clientConnection.appendResponseMessage("Date: ");
-            clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+            clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
             clientConnection.appendResponseMessage("\r\n\r\n");
 
             std::ifstream targetRepresentation(targetRepresentationURI, std::ios_base::binary | std::ios_base::ate);
@@ -117,7 +117,7 @@ int VirtualServer::processGET(Connection& clientConnection) {
 
             // TODO 적절한 헤더 필드 추가하기(content-length)
             clientConnection.appendResponseMessage("Date: ");
-            clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+            clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
             clientConnection.appendResponseMessage("\r\n\r\n");
 
             std::ifstream targetRepresentation(location.getIndex(), std::ios_base::binary | std::ios_base::ate);
@@ -177,7 +177,7 @@ int VirtualServer::processPOST(Connection& clientConnection) {
 
         // TODO 적절한 헤더 필드 추가하기(content-length)
         clientConnection.appendResponseMessage("Date: ");
-        clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+        clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
         clientConnection.appendResponseMessage("\r\n\r\n");
 
         // TODO 적절한 바디 생성하기
@@ -217,7 +217,7 @@ int VirtualServer::processDELETE(Connection& clientConnection) {
 
             // TODO 적절한 헤더 필드 추가하기(content-length)
             clientConnection.appendResponseMessage("Date: ");
-            clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+            clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
             clientConnection.appendResponseMessage("\r\n\r\n");
 
             // TODO 적절한 바디 설정하기
@@ -249,7 +249,7 @@ int VirtualServer::set404Response(Connection& clientConnection) {
 
     // TODO implement
     clientConnection.appendResponseMessage("Date: ");
-    clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+    clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
     clientConnection.appendResponseMessage("\r\n\r\n");
 
     return 0;
@@ -264,7 +264,7 @@ int VirtualServer::set405Response(Connection& clientConnection, const Location* 
 
     // TODO implement
     clientConnection.appendResponseMessage("Date: ");
-    clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+    clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
     clientConnection.appendResponseMessage("\r\n");
 
     clientConnection.appendResponseMessage("Allow: ");
@@ -291,7 +291,7 @@ int VirtualServer::set500Response(Connection& clientConnection) {
 
     // TODO append header section and body
     clientConnection.appendResponseMessage("Date: ");
-    clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+    clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
     clientConnection.appendResponseMessage("\r\n\r\n");
 
     return 0;
@@ -330,7 +330,7 @@ int VirtualServer::setListResponse(Connection& clientConnection, const std::stri
     clientConnection.appendResponseMessage("Connection: keep-alive\r\n");
     clientConnection.appendResponseMessage("Content-Type: text/html\r\n");
     clientConnection.appendResponseMessage("Date: ");
-    clientConnection.appendResponseMessage(clientConnection.makeHeaderField(HTTP::DATE));
+    clientConnection.appendResponseMessage(this->makeHeaderField(HTTP::DATE));
     clientConnection.appendResponseMessage("\r\n");
     clientConnection.appendResponseMessage("Server: crash-webserve\r\n");
     clientConnection.appendResponseMessage("\r\n");
@@ -369,3 +369,31 @@ int VirtualServer::setListResponse(Connection& clientConnection, const std::stri
 
     return 0;
 }
+
+std::string VirtualServer::makeHeaderField(unsigned short fieldName) {
+    switch (fieldName)
+    {
+    case HTTP::DATE:
+        return makeDateHeaderField();
+    // case HTTP::ALLOW:
+    //     return makeAllowHeaderField();
+    }
+    return ""; // TODO delete
+}
+
+// Find the current time based on GMT
+//  - Parameters(None)
+//  - Return
+//      Current time based on GMT(std::string)
+std::string VirtualServer::makeDateHeaderField() {
+    char cDate[1000];
+    time_t rr = time(0);
+    struct tm tm = *gmtime(&rr);
+    strftime(cDate, sizeof(cDate), "%a, %d %b %Y %H:%M:%S GMT", &tm);
+    std::string dateStr = cDate;
+    return dateStr;
+}
+
+// std::string Connection::makeAllowHeaderField() {
+    
+// }

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -92,6 +92,10 @@ public:
     void appendLocation(Location* lc) { this->_location.push_back(lc); };
     VirtualServer::ReturnCode processRequest(Connection& clientConnection);
 
+    std::string makeHeaderField(unsigned short fieldName);
+    std::string makeDateHeaderField();
+    // std::string makeAllowHeaderField();
+
 private:
     port_t _portNumber;
     std::string _name;


### PR DESCRIPTION
# Description
- 헤더필드를 만드는 메소드를 connection 에서 virtualServer로 이전
- (Hotfix) allow method 초기화 부분 수정

# Test
- make re && ./webserve conf/sample.conf 정상동작합니다.
- 현재 sample.conf에는 allow_method가 정의되있지 않아 GET, POST, DELETE 다 허용할 겁니다. 수정해서 테스트하시는걸 권장합니다.