### PR TITLE
Hotfix : parsing Host headerfield from req msg

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -241,9 +241,10 @@ VirtualServer& FTServer::getTargetVirtualServer(Connection& clientConnection) {
     int cntVirtualServers = this->_vVirtualServers.size();
     const std::string* tHostName = clientConnection.getRequest().getFirstHeaderFieldValueByName("Host");
     if (tHostName != NULL) {
+        std::string tServerName = tHostName->substr(0, tHostName->find_first_of(":"));
         for (int i = 0; i < cntVirtualServers; i++) {
             if ((this->_vVirtualServers[i]->getPortNumber() == clientConnection.getPort()) &&
-                (this->_vVirtualServers[i]->getServerName() == *tHostName))
+                (this->_vVirtualServers[i]->getServerName() == tServerName))
                 return *this->_vVirtualServers[i];
         }
     }


### PR DESCRIPTION
# Description
- (fix) Host 헤더필드 뒤에오는 포트를 제거해 도메인과 서버네임을 비교하도록 수정

# Issue
- req host에 있는 값을 virtual server에 있는 서버네임과 비교한 결과 포트가 붙은 경우 제대로 비교를 못하고 넘어가는 현상 발견

# Test
- make re && ./webserve ./conf/sample.conf 정상작동합니다.