### PR TITLE
UNPQ-75 add dummy virtual server

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -97,9 +97,9 @@ void FTServer::init() {
     this->initializeConnection(portsOpen, portsOpen.size());
 }
 
-//  TODO Implement real behavior.
 //  Initialize all virtual servers from virtual server config set.
 void FTServer::initializeVirtualServers() {
+    this->addDummyVirtualServer();
     for (VirtualServerConfigIter itr = this->_defaultConfigs.begin(); itr != this->_defaultConfigs.end(); itr++) {
         VirtualServer* newVirtualServer = this->makeVirtualServer(*itr);
         this->_vVirtualServers.push_back(newVirtualServer);
@@ -107,7 +107,14 @@ void FTServer::initializeVirtualServers() {
     }
 }
 
-//  TODO Implement real one virtual server using config
+//  make dummy virtualServer.
+//  dummy virtualServer process request targetting no virtualServer.
+//  - Parameters(None)
+//  - Return(None)
+void FTServer::addDummyVirtualServer() {
+    this->_vVirtualServers.push_back(new VirtualServer());
+}
+
 VirtualServer*    FTServer::makeVirtualServer(VirtualServerConfig* virtualServerConf) {
     VirtualServer* newVirtualServer;
     directiveContainer config = virtualServerConf->getConfigs();           // original config in server Block
@@ -166,7 +173,6 @@ VirtualServer*    FTServer::makeVirtualServer(VirtualServerConfig* virtualServer
 }
 
 // Prepares sockets as descripted by the server configuration.
-// TODO: make it works with actuall server config!
 //  - Parameter
 //  - Return(none)
 void FTServer::initializeConnection(std::set<port_t>& ports, int size) {

--- a/FTServer.hpp
+++ b/FTServer.hpp
@@ -66,6 +66,7 @@ private:
     int             _kqueue;
     bool            _alive;
 
+    void addDummyVirtualServer();
     VirtualServer* makeVirtualServer(VirtualServerConfig* serverConf);
     void acceptConnection(Connection* connection);
     void closeConnection(int ident);


### PR DESCRIPTION
- add dummy virtual server to generate for request unknown targetting virtual server.

## Description

request line 파싱 에러 등으로 인해 타겟 가상 서버가 존재하지 않는 요청을 처리하기 위한 용도의 더미 가상 서버를 ftServer._vVirtualServers에 추가했습니다.

## Test

make re && ./webserve custom.conf 자체 설정 파일 테스트를 통과했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂