### PR TITLE
UNPQ-79 refactor: make getMatchingLocation()

### DIFF
--- a/Location.cpp
+++ b/Location.cpp
@@ -14,7 +14,7 @@ _allowedHTTPMethod(7)
 //      resourceURI: The resource path to convert to local path.
 //      representationPath: The path of representation for resource.
 //  - Return(None)
-void Location::getRepresentationPath(const std::string& resourceURI, std::string& representationPath) const {
+void Location::updateRepresentationPath(const std::string& resourceURI, std::string& representationPath) const {
     representationPath = this->_root + '/';
     representationPath += (resourceURI.c_str() + this->_route.length());
 }

--- a/Location.hpp
+++ b/Location.hpp
@@ -21,7 +21,7 @@ public:
     Location();
     bool isRouteMatch(const std::string& resourceURI) const;
     bool isRequestMethodAllowed(HTTP::RequestMethod requestMethod) const;
-    void getRepresentationPath(const std::string& resourceURI, std::string& representationPath) const;
+    void updateRepresentationPath(const std::string& resourceURI, std::string& representationPath) const;
 
     std::string getRoute() { return this->_route; };
     std::string getRoot() const { return this->_root; };

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -104,6 +104,8 @@ private:
 
     std::map<std::string, std::string> _others;
 
+    const Location* getMatchingLocation(const Request& request);
+
     int processGET(Connection& clientConnection);
     int processPOST(Connection& clientConnection);
     int processDELETE(Connection& clientConnection);


### PR DESCRIPTION
- make VirtualServer::getMatchingLocation().
- rename getRepresentationPath() to updateRepresentationPath().
- change status code when processPOST() couldn't find matching location, from 405 -> 404.
- modify processDelete() not to check whether the representation is directory or not.

## Description

`client_max_body_size에 따른 413 응답 반환` 로직을 짜기 전에 `요청의 resourceURI에 매칭하는 route를 가진 location 객체를 탐색하는 로직을 모듈화` 하는 리팩토링을 진행했습니다.
- VirtualServer::getMatchingLocation() 작성
- `getRepresentationPath()` 을 `updateRepresentationPath()` 로 이름 변경
- `processPOST()` 에서 요청의 리소스 URI에 일치하는 route를 가진 location 객체가 존재하지 않는 경우 기존 `405` 응답을 반환하던 것을 `404` 응답을 반환하도록 변경
- `processDelete()` 에서 representation이 디렉토리인지 판단하는 로직 삭제

## Test

make re && ./webserve custom.conf 자체 설정 파일 테스트를 통과했습니다.
GET 요청 메서드 테스트를 통과했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂