### PR TITLE
Unpq 76 limit body size

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -221,7 +221,7 @@ void FTServer::read(Connection* connection) {
             break;
         case RCRECV_SOME:
             break;
-        case RCRECV_PARSING_SUCCESS:
+        case RCRECV_PARSING_FINISH:
             VirtualServer& targetVirtualServer = this->getTargetVirtualServer(*connection);
             if (targetVirtualServer.processRequest(*connection) == VirtualServer::RC_SUCCESS)
                 connection->addKevent(this->_kqueue, EVFILT_WRITE, NULL);
@@ -236,7 +236,7 @@ void FTServer::read(Connection* connection) {
 VirtualServer& FTServer::getTargetVirtualServer(Connection& clientConnection) {
     //  TODO Implement real behavior. Change the return type from reference to pointer type.
     int cntVirtualServers = this->_vVirtualServers.size();
-    const std::string* tHostName = clientConnection.getRequest().getFirstHeaderFieldValueByName("Host");
+    const std::string* tHostName = clientConnection.getRequest().getFirstHeaderFieldValueByName("host");
     if (tHostName != NULL) {
         std::string tServerName = tHostName->substr(0, tHostName->find_first_of(":"));
         for (int i = 0; i < cntVirtualServers; i++) {

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -221,9 +221,6 @@ void FTServer::read(Connection* connection) {
             break;
         case RCRECV_SOME:
             break;
-        case RCRECV_PARSING_FAIL:
-            //  TODO Implement behavior
-            break;
         case RCRECV_PARSING_SUCCESS:
             VirtualServer& targetVirtualServer = this->getTargetVirtualServer(*connection);
             if (targetVirtualServer.processRequest(*connection) == VirtualServer::RC_SUCCESS)

--- a/Location.cpp
+++ b/Location.cpp
@@ -1,3 +1,4 @@
+#include <sstream>
 #include "Location.hpp"
 
 Location::Location():
@@ -17,4 +18,22 @@ _allowedHTTPMethod(7)
 void Location::updateRepresentationPath(const std::string& resourceURI, std::string& representationPath) const {
     representationPath = this->_root + '/';
     representationPath += (resourceURI.c_str() + this->_route.length());
+}
+
+//  get client_max_body_size value.
+//  - Parameters(None)
+//  - Return: client_max_body_size value in int.
+int Location::getClientMaxBodySize() const {
+    const std::map<std::string, std::string>::const_iterator iter = this->_others.find("client_max_body_size");
+    if (iter != this->_others.end()) {
+        std::istringstream iss(iter->second);
+        int maxBodySize;
+        iss >> maxBodySize;
+        if (!iss)
+            return INT_MAX;
+
+        return maxBodySize;
+    }
+
+    return INT_MAX;
 }

--- a/Location.cpp
+++ b/Location.cpp
@@ -14,7 +14,7 @@ _allowedHTTPMethod(7)
 //      resourceURI: The resource path to convert to local path.
 //      representationPath: The path of representation for resource.
 //  - Return(None)
-void Location::getRepresentationPath(const std::string& resourceURI, std::string& representationPath) const {
+void Location::updateRepresentationPath(const std::string& resourceURI, std::string& representationPath) const {
     representationPath = this->_root + '/';
     representationPath += (resourceURI.c_str() + this->_route.length());
 }

--- a/Location.hpp
+++ b/Location.hpp
@@ -21,7 +21,7 @@ public:
     Location();
     bool isRouteMatch(const std::string& resourceURI) const;
     bool isRequestMethodAllowed(HTTP::RequestMethod requestMethod) const;
-    void getRepresentationPath(const std::string& resourceURI, std::string& representationPath) const;
+    void updateRepresentationPath(const std::string& resourceURI, std::string& representationPath) const;
 
     std::string getRoute() { return this->_route; };
     std::string getRoot() const { return this->_root; };

--- a/Location.hpp
+++ b/Location.hpp
@@ -29,6 +29,7 @@ public:
     bool getAutoIndex() const { return this->_autoindex; };
     char getAllowedHTTPMethod() { return this->_allowedHTTPMethod; };
     std::vector<std::string> getCGIExtention() { return this->_cgiExtension; }
+    int getClientMaxBodySize() const;
 
     void setRoute(std::string route) { this->_route = route; };
     void setRoot(std::string root) { this->_root = root; };

--- a/Request.cpp
+++ b/Request.cpp
@@ -1,10 +1,12 @@
 #include <sys/socket.h>
 #include <sstream>
 #include <string>
-#include <ctype.h>
+#include <cctype>
 #include <cassert>
 #include "Request.hpp"
 #include "constant.hpp"
+
+static void tolower(std::string& value);
 
 //  Destructor of Request object.
 Request::~Request() {
@@ -35,7 +37,9 @@ ReturnCaseOfRecv Request::receive(int clientSocketFD) {
 
     if (this->isReadyToProcess()) {
         this->_parsingStatus = this->parseMessage();
-        return RCRECV_PARSING_SUCCESS;
+        if (this->_parsingStatus == S_PARSING_FAIL)
+            this->_message.clear();
+        return RCRECV_PARSING_FINISH;
     }
 
     return RCRECV_SOME;
@@ -45,14 +49,14 @@ ReturnCaseOfRecv Request::receive(int clientSocketFD) {
 //  - Parameters(None)
 //  - Return: Whether request received the end of header section or not.
 bool Request::isReadyToProcess() const {
-    return (this->_message.find("\x0d\x0a\x0d\x0a") != std::string::npos);
+    return (this->_message.find("\r\n\r\n") != std::string::npos);
 }
 
 //  Return whether the body is chunked or not.
 //  - Parameters(None)
 //  - Return: Whether the body is chunked or not.
 bool Request::isChunked() const {
-    const std::string* headerFieldValue = getFirstHeaderFieldValueByName("Transfer-Encoding");
+    const std::string* headerFieldValue = getFirstHeaderFieldValueByName("transfer-encoding");
     if (headerFieldValue == NULL)
         return false;
 
@@ -90,38 +94,57 @@ void Request::appendMessage(const char* message) {
 //  Parse HTTP request message.
 //  - Parameters(None)
 //  - Return: Whether the parsing succeeded or not.
-ParsingResult Request::parseMessage() {
+Request::Status Request::parseMessage() {
     std::istringstream iss(this->_message);
     std::string line;
 
     if (!std::getline(iss, line, '\r'))
-        return PR_FAIL;
+        return S_PARSING_FAIL;
     if (this->parseRequestLine(line) == PR_FAIL)
-        return PR_FAIL;
+        return S_PARSING_FAIL;
 
+    this->_headerSection.clear();
     while (true) {
         iss.get();
         if (!std::getline(iss, line, '\r'))
-            return PR_FAIL;
+            return S_PARSING_FAIL;
         if (line.empty())
             break;
         if (parseHeader(line) == PR_FAIL)
-            return PR_FAIL;
+            return S_PARSING_FAIL;
     }
 
     if (iss.get() != '\n')
-        return PR_FAIL;
+        return S_PARSING_FAIL;
+
+    if (this->_method == (HTTP::RM_GET | HTTP::RM_DELETE)) {
+        this->_message.erase(0, iss.tellg());
+        return S_PARSING_SUCCESS;
+    }
 
     if (this->isChunked()) {
-        if (parseChunkToBody(iss) == PR_FAIL)
-            return PR_FAIL;
+        if (this->parseChunkToBody(iss) == PR_FAIL)
+            return S_PARSING_FAIL;
     }
-    else
-        this->_body = this->_message.substr(iss.tellg());
+    else {
+        const std::string* headerFieldValue = getFirstHeaderFieldValueByName("content-length");
+        if (headerFieldValue != NULL) {
+            std::istringstream sizeStream(*headerFieldValue);
+            unsigned long bodySize;
+            sizeStream >> bodySize;
+            if (!sizeStream || sizeStream.get() != EOF)
+                return S_PARSING_FAIL;
+            this->_body = this->_message.substr(iss.tellg(), bodySize);
+        }
+        else if (iss.get() != EOF) {
+            this->_message.clear();
+            return S_LENGTH_REQUIRED;
+        }
+    }
 
-    this->_message.clear();
+    this->_message.erase(0, static_cast<unsigned long>(iss.tellg()) + this->_body.length());
 
-    return PR_SUCCESS;
+    return S_PARSING_SUCCESS;
 }
 
 //  Parse HTTP request line.
@@ -131,16 +154,10 @@ ParsingResult Request::parseRequestLine(const std::string& requestLine) {
     std::istringstream iss(requestLine);
     std::string token;
 
-    if (iss >> token)
-        this->_method = requestMethodByString(token);
-    else
-        return PR_FAIL;
-
-    if (iss >> token)
-        this->_target = token;
-    else
-        return PR_FAIL;
-
+    iss >> token;
+    this->_method = requestMethodByString(token);
+    iss >> token;
+    this->_target = token;
     if (iss >> token)
         return parseHTTPVersion(token);
     else
@@ -184,14 +201,15 @@ ParsingResult Request::parseHeader(const std::string& headerField) {
         return PR_FAIL;
     if (!iss.get(ch))
         return PR_FAIL;
-    if (!(ch == '\x09' || ch == ' '))
+    if (!(ch == '\t' || ch == ' '))
         iss.putback(ch);
     if (!std::getline(iss, value))
         return PR_FAIL;
     ch = value[value.length() - 1];
-    if (ch == '\x09' || ch == ' ')
+    if (ch == '\t' || ch == ' ')
         value.erase(value.length() - 1);
 
+    tolower(name);
     this->_headerSection.push_back(new HeaderSectionElementType(name, value));
 
     return PR_SUCCESS;
@@ -202,22 +220,21 @@ ParsingResult Request::parseHeader(const std::string& headerField) {
 //  - Return: Whether the parsing succeeded or not.
 ParsingResult Request::parseChunkToBody(std::istringstream& iss) {
     this->_body.clear();
-    int contentLength = 0;
+
     while (true) {
         const std::ios_base::fmtflags ff = iss.flags();
         iss.setf(std::ios_base::hex, std::ios_base::basefield);
         int chunkLength;
+        if (std::isspace(iss.peek()))
+            return PR_FAIL;
         iss >> chunkLength;
-        contentLength += chunkLength;
         iss.flags(ff);
         iss.get();
         iss.get();
-        if (!iss)
-            return PR_FAIL;
-        std::string chunk;
-        std::getline(iss, chunk, '\r');
+        std::string chunk(chunkLength, '\0');
+        iss.read(&chunk[0], chunkLength);
         this->_body += chunk;
-        if (iss.get() != '\n')
+        if (iss.get() != '\r' || iss.get() != '\n')
             return PR_FAIL;
         if (chunkLength == 0)
             break;
@@ -242,4 +259,12 @@ HTTP::RequestMethod Request::requestMethodByString(const std::string& token) {
         method = HTTP::RM_UNKNOWN;
 
     return method;
+}
+
+//  make value to lower case string.
+//  - Parameters value: the string to make lower case.
+//  - Return(None)
+static void tolower(std::string& value) {
+    for (std::string::iterator iter = value.begin(); iter != value.end(); ++iter)
+        *iter = tolower(*iter);
 }

--- a/Request.cpp
+++ b/Request.cpp
@@ -34,13 +34,37 @@ ReturnCaseOfRecv Request::receive(int clientSocketFD) {
         return RCRECV_ZERO;
 
     if (this->isReadyToProcess()) {
-        if (this->parseMessage() == PR_SUCCESS) //  TODO Pass valid string to parseMessage and left remain string.
+        if (this->parseMessage() == PR_SUCCESS)
             return RCRECV_PARSING_SUCCESS;
         else
             return RCRECV_PARSING_FAIL;
     }
 
     return RCRECV_SOME;
+}
+
+//  Returns whether Request received the end of header section or not.
+//  - Parameters(None)
+//  - Return: Whether request received the end of header section or not.
+bool Request::isReadyToProcess() const {
+    return (this->_message.find("\x0d\x0a\x0d\x0a") != std::string::npos);
+}
+
+//  Return whether the body is chunked or not.
+//  - Parameters(None)
+//  - Return: Whether the body is chunked or not.
+bool Request::isChunked() const {
+    const std::string* headerFieldValue = getFirstHeaderFieldValueByName("Transfer-Encoding");
+    if (headerFieldValue == NULL)
+        return false;
+
+    std::istringstream iss(*headerFieldValue);
+    std::string word;
+    std::getline(iss, word, ',');
+    if (iss.eof())
+        return (word == "chunked");
+    else
+        return false;
 }
 
 //  Receive message from client.
@@ -65,13 +89,6 @@ void Request::appendMessage(const char* message) {
     this->_message += message;
 }
 
-//  Returns whether Request received the end of header section or not.
-//  - Parameters(None)
-//  - Return: Whether request received the end of header section or not.
-bool Request::isReadyToProcess() const {
-    return (this->_message.find("\x0d\x0a\x0d\x0a") != std::string::npos);
-}
-
 //  Parse HTTP request message.
 //  - Parameters(None)
 //  - Return: Whether the parsing succeeded or not.
@@ -79,15 +96,14 @@ ParsingResult Request::parseMessage() {
     std::istringstream iss(this->_message);
     std::string line;
 
-    if (!std::getline(iss, line, '\x0d'))
+    if (!std::getline(iss, line, '\r'))
         return PR_FAIL;
     if (this->parseRequestLine(line) == PR_FAIL)
         return PR_FAIL;
 
     while (true) {
-        if (iss.get() == EOF || !iss)
-            return PR_FAIL;
-        if (!std::getline(iss, line, '\x0d'))
+        iss.get();
+        if (!std::getline(iss, line, '\r'))
             return PR_FAIL;
         if (line.empty())
             break;
@@ -95,10 +111,15 @@ ParsingResult Request::parseMessage() {
             return PR_FAIL;
     }
 
-    if (iss.get() == EOF || !iss)
+    if (iss.get() != '\n')
         return PR_FAIL;
 
-    this->_body = this->_message.substr(iss.tellg());
+    if (this->isChunked()) {
+        if (parseChunkToBody(iss) == PR_FAIL)
+            return PR_FAIL;
+    }
+    else
+        this->_body = this->_message.substr(iss.tellg());
 
     this->_message.clear();
 
@@ -174,6 +195,35 @@ ParsingResult Request::parseHeader(const std::string& headerField) {
         value.erase(value.length() - 1);
 
     this->_headerSection.push_back(new HeaderSectionElementType(name, value));
+
+    return PR_SUCCESS;
+}
+
+//  Parse chunked body.
+//  - Parameters iss: input string stream of body.
+//  - Return: Whether the parsing succeeded or not.
+ParsingResult Request::parseChunkToBody(std::istringstream& iss) {
+    this->_body.clear();
+    int contentLength = 0;
+    while (true) {
+        const std::ios_base::fmtflags ff = iss.flags();
+        iss.setf(std::ios_base::hex, std::ios_base::basefield);
+        int chunkLength;
+        iss >> chunkLength;
+        contentLength += chunkLength;
+        iss.flags(ff);
+        iss.get();
+        iss.get();
+        if (!iss)
+            return PR_FAIL;
+        std::string chunk;
+        std::getline(iss, chunk, '\r');
+        this->_body += chunk;
+        if (iss.get() != '\n')
+            return PR_FAIL;
+        if (chunkLength == 0)
+            break;
+    }
 
     return PR_SUCCESS;
 }

--- a/Request.cpp
+++ b/Request.cpp
@@ -34,10 +34,8 @@ ReturnCaseOfRecv Request::receive(int clientSocketFD) {
         return RCRECV_ZERO;
 
     if (this->isReadyToProcess()) {
-        if (this->parseMessage() == PR_SUCCESS) //  TODO Pass valid string to parseMessage and left remain string.
-            return RCRECV_PARSING_SUCCESS;
-        else
-            return RCRECV_PARSING_FAIL;
+        this->_parsingStatus = this->parseMessage();
+        return RCRECV_PARSING_SUCCESS;
     }
 
     return RCRECV_SOME;

--- a/Request.hpp
+++ b/Request.hpp
@@ -95,14 +95,17 @@ private:
 
     std::string _body;
 
+    bool isReadyToProcess() const;
+    bool isChunked() const;
+
     ssize_t receiveMessage(int clientSocketFD);
     void appendMessage(const char* message);
-    bool isReadyToProcess() const;
 
     ParsingResult parseMessage();
     ParsingResult parseRequestLine(const std::string& requestLine);
     ParsingResult parseHTTPVersion(const std::string& token);
     ParsingResult parseHeader(const std::string& headerField);
+    ParsingResult parseChunkToBody(std::istringstream& iss);
 
     HTTP::RequestMethod requestMethodByString(const std::string& token);
 };

--- a/Request.hpp
+++ b/Request.hpp
@@ -52,7 +52,6 @@ enum ReturnCaseOfRecv {
     RCRECV_ERROR = -1,
     RCRECV_ZERO,
     RCRECV_SOME,
-    RCRECV_PARSING_FAIL,
     RCRECV_PARSING_SUCCESS,
 };
 
@@ -66,6 +65,8 @@ enum ReturnCaseOfRecv {
 //      _minorVersion: Parsed major version.
 //      _headerSection: Parsed header field vector.
 //      _body: Parsed payload body.
+//
+//      _parsingStatus: store parsing status.
 class Request {
 public:
     typedef std::pair<std::string, std::string> HeaderSectionElementType;
@@ -81,6 +82,8 @@ public:
     const std::string* getFirstHeaderFieldValueByName(const std::string& name) const;
     const std::string& getBody() const { return this->_body; };
 
+    bool isParsingFail() const { return this->parsingStatus == PR_FAIL; };
+
     ReturnCaseOfRecv receive(int clientSocketFD);
 
 private:
@@ -94,6 +97,8 @@ private:
     HeaderSectionType _headerSection;
 
     std::string _body;
+
+    ParsingResult _parsingStatus;
 
     ssize_t receiveMessage(int clientSocketFD);
     void appendMessage(const char* message);

--- a/Request.hpp
+++ b/Request.hpp
@@ -47,12 +47,12 @@ enum HeaderFieldName{
 //      RCRECV_ZERO: Nothing received.
 //      RCRECV_SOME: Received some message but not enough to process.
 //      RCRECV_PARSING_FAIL: Received enough message to process, but failed parsing.
-//      RCRECV_PARSING_SUCCESS: Received enough message to process, and succeeded parsing.
+//      RCRECV_PARSING_FINISH: Received enough message to process, and succeeded parsing.
 enum ReturnCaseOfRecv {
     RCRECV_ERROR = -1,
     RCRECV_ZERO,
     RCRECV_SOME,
-    RCRECV_PARSING_SUCCESS,
+    RCRECV_PARSING_FINISH,
 };
 
 //  Accumulate HTTP request message and parse it and store.
@@ -69,6 +69,12 @@ enum ReturnCaseOfRecv {
 //      _parsingStatus: store parsing status.
 class Request {
 public:
+    enum Status {
+        S_PARSING_FAIL,
+        S_PARSING_SUCCESS,
+        S_LENGTH_REQUIRED,
+    };
+
     typedef std::pair<std::string, std::string> HeaderSectionElementType;
     typedef std::vector<HeaderSectionElementType*> HeaderSectionType;
 
@@ -82,7 +88,8 @@ public:
     const std::string* getFirstHeaderFieldValueByName(const std::string& name) const;
     const std::string& getBody() const { return this->_body; };
 
-    bool isParsingFail() const { return this->parsingStatus == PR_FAIL; };
+    bool isParsingFail() const { return this->_parsingStatus == S_PARSING_FAIL; };
+    bool isLengthRequired() const { return this->_parsingStatus == S_LENGTH_REQUIRED; };
 
     ReturnCaseOfRecv receive(int clientSocketFD);
 
@@ -98,7 +105,7 @@ private:
 
     std::string _body;
 
-    ParsingResult _parsingStatus;
+    Status _parsingStatus;
 
     bool isReadyToProcess() const;
     bool isChunked() const;
@@ -106,7 +113,7 @@ private:
     ssize_t receiveMessage(int clientSocketFD);
     void appendMessage(const char* message);
 
-    ParsingResult parseMessage();
+    Status parseMessage();
     ParsingResult parseRequestLine(const std::string& requestLine);
     ParsingResult parseHTTPVersion(const std::string& token);
     ParsingResult parseHeader(const std::string& headerField);

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -104,6 +104,8 @@ private:
 
     std::map<std::string, std::string> _others;
 
+    const Location* getMatchingLocation(const Request& request);
+
     int processGET(Connection& clientConnection);
     int processPOST(Connection& clientConnection);
     int processDELETE(Connection& clientConnection);

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -112,8 +112,11 @@ private:
 
     void setStatusLine(Connection& clientConnection, HTTP::Status::Index index);
 
+    int set400Response(Connection& clientConnection);
     int set404Response(Connection& clientConnection);
     int set405Response(Connection& clientConnection, const Location* locations);
+    int set411Response(Connection& clientConnection);
+    int set413Response(Connection& clientConnection);
     int set500Response(Connection& clientConnection);
     int setListResponse(Connection& clientConnection, const std::string& path);
 };  // VirtualServer


### PR DESCRIPTION
## Description

- `RCRECV_PARSING_SUCCESS`을 `RCRECV_PARSING_FINISH`로 변경하였습니다.
- 파싱 상황에 따라 `request._message`와 `request._headerSection`의 값을 적절히 초기화 하도록 수정했습니다.
- request 에 내부적으로 추가적인 상태 값을 기록하는 `_status` 변수를 추가했습니다.
	- 추가된 Request::Status 타입을 가지며, 파싱의 성공, 실패(400) 및 411 응답을 반환해야 하는 상태인지를 저장합니다.
		- 400 과 411 은 메서드에 따른 요청 처리가 실행되기 전에 응답을 반환하고 요청 처리를 마칩니다.
- Content-Length 헤더 필드의 값만큼 body를 읽도록 수정하였습니다.
- 405 응답이 두 번째 인자로 NULL을 받을 때 nginx 처럼 `Allow` 헤더 필드를 출력하지 않도록 수정하였습니다.
- 요청 헤더 필드의 이름을 lower case 로 저장

## Test

`make re && ./webserve custom.conf`로 컴파일 및 자체 설정 파일 테스트를 통과했습니다.

GET 요청 메서드 테스트를 통과했습니다.
POST 요청 처리 테스트를 통과했습니다.
여러 POST 요청을 연속하여 처리하는 테스트를 통과했습니다.
chunked body를 가지는 POST 요청에 대해 제대로 파싱하는 것을 확인했습니다.
chunked body를 가지는 POST 요청에 대해 형식이 틀렸을 때 400 응답을 반환하는 테스트를 통과했습니다.
DELETE 요청 처리 테스트를 통과했습니다.
요청 메세지 파싱에 실패했을 때 400응답을 반환하지는 확인하는 테스트를 통과했습니다.
GET, POST, DELETE 가 아닌 것이 요청 메세지의 메서드 위치에 올 경우 nginx와 마찬가지로 405 응답을 반환하는지 확인하는 테스트를 통과했습니다.
POST 요청 메세지에 `Transfer-Encoding`이 없는데 `Content-Length`도 없을 때 411 응답을 반환하는지 확인하는 테스트를 통과했습니다.
client_max_body_size를 넘으면 413 응답을 반환하는지 확인하는 테스트를 통과했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂