### PR TITLE
UNPQ-80 feat : make redirection 301

### DIFF
--- a/Location.cpp
+++ b/Location.cpp
@@ -24,9 +24,9 @@ void Location::updateRepresentationPath(const std::string& resourceURI, std::str
 //  - Parameters(None)
 //  - Return: client_max_body_size value in int.
 int Location::getClientMaxBodySize() const {
-    const std::map<std::string, std::string>::const_iterator iter = this->_others.find("client_max_body_size");
+    const std::map<std::string, std::vector<std::string> >::const_iterator iter = this->_others.find("client_max_body_size");
     if (iter != this->_others.end()) {
-        std::istringstream iss(iter->second);
+        std::istringstream iss(iter->second[0]);
         int maxBodySize;
         iss >> maxBodySize;
         if (!iss)

--- a/Location.hpp
+++ b/Location.hpp
@@ -52,7 +52,7 @@ public:
     };
     void setCGIExtention(std::vector<std::string> cgiExt) { this->_cgiExtension = cgiExt; }
     void setOtherDirective(std::string directiveName, std::vector<std::string> directiveValue) { 
-        _others.insert(make_pair(directiveName, directiveValue[0])); // TODO multi-value
+        _others.insert(make_pair(directiveName, directiveValue));
     };
 
 private:
@@ -63,7 +63,7 @@ private:
     char _allowedHTTPMethod;
     std::vector<std::string> _cgiExtension;
 
-    std::map<std::string, std::string> _others;
+    std::map<std::string, std::vector<std::string> > _others;
 };
 
 //  Return whether the resource path is match to this->_route.

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -87,7 +87,7 @@ public:
     void setServerName(std::string serverName) { this->_name = serverName; }
     void setClientMaxBodySize(std::size_t clientMaxBodySize) { this->_clientMaxBodySize = clientMaxBodySize; };
     void setOtherDirective(std::string directiveName, std::vector<std::string> directiveValue) { 
-        _others.insert(make_pair(directiveName, directiveValue[0])); // TODO multi-value
+        this->_others.insert(make_pair(directiveName, directiveValue)); // TODO multi-value
     };
     void appendLocation(Location* lc) { this->_location.push_back(lc); };
     VirtualServer::ReturnCode processRequest(Connection& clientConnection);
@@ -95,6 +95,7 @@ public:
     std::string makeHeaderField(unsigned short fieldName);
     std::string makeDateHeaderField();
     // std::string makeAllowHeaderField();
+    std::string makeContentLocationHeaderField();
 
 private:
     port_t _portNumber;
@@ -102,7 +103,7 @@ private:
     std::size_t _clientMaxBodySize;
     std::vector<Location*> _location;
 
-    std::map<std::string, std::string> _others;
+    std::map<std::string, std::vector<std::string> > _others;
 
     const Location* getMatchingLocation(const Request& request);
 
@@ -113,6 +114,7 @@ private:
     void setStatusLine(Connection& clientConnection, HTTP::Status::Index index);
 
     int set400Response(Connection& clientConnection);
+    int set301Response(Connection& clientConnection);
     int set404Response(Connection& clientConnection);
     int set405Response(Connection& clientConnection, const Location* locations);
     int set411Response(Connection& clientConnection);

--- a/conf/sample.conf
+++ b/conf/sample.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name localhost1;
 
     location / {
         autoindex on;
@@ -13,7 +13,7 @@ server {
 }
 server {
     listen 8080;
-    server_name localhost;
+    server_name localhost2;
 
     location / {
         autoindex on;

--- a/conf/sample.conf
+++ b/conf/sample.conf
@@ -1,49 +1,31 @@
 server {
     listen 80;
-    server_name google.com www.google.com;
-    root /var/www/html;
+    server_name localhost;
 
     location / {
         autoindex on;
-        index   index.html index.htm;
+        root    /Users/mike2ox/Project/webserve;
     }
-    location /post {
-        root   html;
-        client_max_body_size 10m;
+    location /first {
+        root    /Users/mike2ox/Project/webserve;
     }
-    return 301 https://www.google.com;
+    return 301 http://localhost:8080/;
 }
 server {
-    listen 80;
-    server_name google.com www.google2.com;
-    root /var/www/html;
+    listen 8080;
+    server_name localhost;
 
     location / {
         autoindex on;
-        index   index.html index.htm;
+        root    /Users/mike2ox/Project/webserve;
     }
-    location /post {
-        root   html;
-        client_max_body_size 10m;
-    }
-    return 301 https://www.google.com;
 }
-
 server {
-	listen 443;
+    listen 8081;
+    server_name webserve3;
 
-	ssl on;
-	ssl_certificate /etc/ssl/certs/localhost.dev.crt;
-	ssl_certificate_key /etc/ssl/private/localhost.dev.key;
-
-	root /var/www/html;
-
-	index index.php index.html index.htm;
-
-	server_name _;
-
-	location / {
-		autoindex off;
-		try_files $uri $uri/ =404;
-	}
+    location / {
+        autoindex on;
+        root    /Users/mike2ox/Project/webserve;
+    }
 }

--- a/redirect.html
+++ b/redirect.html
@@ -1,0 +1,7 @@
+<html>
+<head><title>301 Moved Permanently</title></head>
+<body bgcolor="white">
+<center><h1>301 Moved Permanently</h1></center>
+<hr><center>crash webserve</center>
+</body>
+</html>


### PR DESCRIPTION
## Description
- return 인자를 제대로 받기 위해 _other의 2번재 인자를 vector<string>으로 변경
- Location 헤더필드는 리터럴로 넣어둔 상태 -> 다음 커밋때 제대로 생성하는 함수 제공할 예정

## Test
[웹서브 터미널] make re && ./webserve ./conf/sample.conf
[클라이언트 터미널] curl --resolve localhost1:80:127.0.0.1 http://localhost1:80 
단, sample.conf의 root 경로는 테스트하는 pc의 경로로 재설정을 해주셔야 정상동작합니다.