### PR TITLE
UNPQ-20 feat: implement response by status code

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -129,6 +129,11 @@ VirtualServer*    FTServer::makeVirtualServer(VirtualServerConfig* virtualServer
             newVirtualServer->setClientMaxBodySize(cmbs);
             ss.clear();
         }
+        if (itr->first.compare("error_page") == 0) {
+            if (itr->second.size() != 2)
+                continue;
+            newVirtualServer->updateErrorPage(itr->second[0], itr->second[1]);
+        }
         else {
             for (size_t i = 0; i < itr->second.size(); i++)
                 newVirtualServer->setOtherDirective(itr->first, itr->second);

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -122,7 +122,9 @@ private:
     int processPOST(Connection& clientConnection);
     int processDELETE(Connection& clientConnection);
 
-    void setStatusLine(Connection& clientConnection, HTTP::Status::Index index);
+    void appendStatusLine(Connection& clientConnection, HTTP::Status::Index index);
+    void appendDefaultHeaderFields(Connection& clientConnection);
+    void appendContentDefaultHeaderFields(Connection& clientConnection);
     void updateBodyString(HTTP::Status::Index index, const char* description, std::string& bodystring) const;
 
     int set301Response(Connection& clientConnection, const std::map<std::string, std::vector<std::string> >& locOther);

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -37,7 +37,6 @@ struct Status {
         I_201,
         I_301,
         I_400,
-        I_403,
         I_404,
         I_405,
         I_411,
@@ -98,6 +97,8 @@ public:
         this->_others.insert(make_pair(directiveName, directiveValue)); // TODO multi-value
     };
     void appendLocation(Location* lc) { this->_location.push_back(lc); };
+    int updateErrorPage(const std::string& statusCode, const std::string& filePath);
+
     VirtualServer::ReturnCode processRequest(Connection& clientConnection);
 
     std::string makeDateHeaderField();
@@ -113,6 +114,8 @@ private:
 
     std::map<std::string, std::vector<std::string> > _others;
 
+    std::map<std::string, std::string> _errorPage;
+
     const Location* getMatchingLocation(const Request& request);
 
     int processGET(Connection& clientConnection);
@@ -120,9 +123,10 @@ private:
     int processDELETE(Connection& clientConnection);
 
     void setStatusLine(Connection& clientConnection, HTTP::Status::Index index);
+    void updateBodyString(HTTP::Status::Index index, const char* description, std::string& bodystring) const;
 
-    int set400Response(Connection& clientConnection);
     int set301Response(Connection& clientConnection, const std::map<std::string, std::vector<std::string> >& locOther);
+    int set400Response(Connection& clientConnection);
     int set404Response(Connection& clientConnection);
     int set405Response(Connection& clientConnection, const Location* locations);
     int set411Response(Connection& clientConnection);


### PR DESCRIPTION
- implement body generator.
- implement setting custom error page by config.

## Description

default error page를 동적으로 생성하는 함수 작성 및 적용
- POST, DELETE, 301, 400, 404, 405, 411, 413, 500에 적용
config의 error_page 지시자를 사용하여 명시된 파일의 내용을 error page로 사용하는 기능 구현
- 사용법: `error_page 404 /Users/jeonpark/git/debug/contents/webserv/404error.html;`

## Test

make re && ./webserve custom.conf 자체 설정 파일 테스트를 통과했습니다.
error_page를 바꾸면 잘 적용되는 것을 확인했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂