### PR TITLE
UNPQ-89 fix: leaks and throw message

### DIFF
--- a/Connection.cpp
+++ b/Connection.cpp
@@ -145,10 +145,10 @@ void Connection::newSocket() {
     int     enable = 1;
 
     if (0 > newConnection) {
-        throw std::runtime_error("socket() Failed");
+        throw Connection::MAKESOCKETFAIL();
     }
     if (0 > setsockopt(newConnection, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int))) {
-        throw std::runtime_error("setup socket Failed");
+        throw Connection::SETUPSOCKETOPTFAIL();
     }
     // Log::verbose("Connection ( %d ) has been setted to Reusable.", newConnection);
     this->_ident = newConnection;
@@ -172,7 +172,7 @@ void Connection::bindSocket() {
     setAddrStruct(this->_hostPort, addr_in);
     addr = reinterpret_cast<sockaddr*>(&addr_in);
     if (0 > bind(this->_ident, addr, sizeof(*addr))) {
-        throw std::runtime_error("bind error");
+        throw Connection::BINDSOCKETERROR();
     }
 }
 
@@ -180,7 +180,7 @@ void Connection::bindSocket() {
 //  - Return(none)
 void Connection::listenSocket() {
     if (0 > listen(_ident, 10)) {
-        throw std::runtime_error("listen() Failed");
+        throw Connection::LISTENSOCKETERROR();
     }
 }
 

--- a/Connection.cpp
+++ b/Connection.cpp
@@ -145,11 +145,10 @@ void Connection::newSocket() {
     int     enable = 1;
 
     if (0 > newConnection) {
-        throw;
+        throw std::runtime_error("socket() Failed");
     }
-    // Log::verbose("New Server Connection ( %d )", newConnection);
     if (0 > setsockopt(newConnection, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int))) {
-        throw;
+        throw std::runtime_error("setup socket Failed");
     }
     // Log::verbose("Connection ( %d ) has been setted to Reusable.", newConnection);
     this->_ident = newConnection;
@@ -173,18 +172,16 @@ void Connection::bindSocket() {
     setAddrStruct(this->_hostPort, addr_in);
     addr = reinterpret_cast<sockaddr*>(&addr_in);
     if (0 > bind(this->_ident, addr, sizeof(*addr))) {
-        throw; // TODO
+        throw std::runtime_error("bind error");
     }
-    // Log::verbose("Connection ( %d ) bind succeed.", this->_ident);
 }
 
 // Listen to the socket for incoming messages.
 //  - Return(none)
 void Connection::listenSocket() {
     if (0 > listen(_ident, 10)) {
-        throw;
+        throw std::runtime_error("listen() Failed");
     }
-    // Log::verbose("Listening from Connection ( %d ), Port ( %d ).", this->_ident, this->_hostPort);
 }
 
 EventContext::EventResult Connection::passParsedRequest() {

--- a/Connection.hpp
+++ b/Connection.hpp
@@ -51,6 +51,31 @@ public:
     void appendResponseMessage(const std::string& message);
     EventContext::EventResult handleCGIResponse(int CGIPipeOut);
 
+    class MAKESOCKETFAIL: public std::exception {
+    public:
+        virtual const char* what() const throw() {
+            return "socket() fail error";
+        }
+    };
+    class SETUPSOCKETOPTFAIL: public std::exception {
+    public:
+        virtual const char* what() const throw() {
+            return "setsocketopt() faile error";
+        }
+    };
+    class BINDSOCKETERROR: public std::exception {
+    public:
+        virtual const char* what() const throw() {
+            return "bind() fail error";
+        }
+    };
+    class LISTENSOCKETERROR: public std::exception {
+    public:
+        virtual const char* what() const throw() {
+            return "listen() fail error!!";
+        }
+    };
+    
 private:
     bool _client;
     int _ident;

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -14,15 +14,21 @@ _eventHandler(EventHandler()) {
 // Destructor of FTServer
 //  - Parameters(None)
 FTServer::~FTServer() {
-    ConnectionMapIter   connectionIter = _mConnection.begin();
-    for (;connectionIter != _mConnection.end() ; connectionIter++) {
+    for (ConnectionMapIter   connectionIter = _mConnection.begin();
+        connectionIter != _mConnection.end();
+        connectionIter++) {
         delete connectionIter->second;
     }
-
-    for (VirtualServerConfigIter itr = _defaultConfigs.begin(); itr != _defaultConfigs.end(); ++itr) {
+    for (VirtualServerConfigIter itr = _defaultConfigs.begin();
+        itr != _defaultConfigs.end();
+        ++itr) {
         delete (*itr);
     }
-
+    for (VirtualServerVec::iterator itr = _vVirtualServers.begin();
+        itr != _vVirtualServers.end();
+        itr++) {
+        delete *itr;
+    }
     Log::verbose("All Connections has been deleted.");
     // close(_kqueue);
 }

--- a/Log.cpp
+++ b/Log.cpp
@@ -7,13 +7,13 @@ const char* Log::getPrefix(int logLevel) {
         case LogVerbose:
             return "\033[34m[VERBOSE]\033[0m";
         case LogDebug:
-            return "\033[37m[DEBUG]\033[0m";
+            return "\033[37m[DEBUG]  \033[0m";
         case LogInfo:
-            return "\033[32m[INFO]\033[0m";
+            return "\033[32m[INFO]   \033[0m";
         case LogWarning:
             return "\033[33m[WARNING]\033[0m";
         case LogError:
-            return "\033[35m[ERROR]\033[0m";
+            return "\033[35m[ERROR]  \033[0m";
         default:
             return "\033[0m";
     }

--- a/constant.hpp
+++ b/constant.hpp
@@ -3,6 +3,7 @@
 
 const int BUF_SIZE = 1024;
 const std::string REDIRECT_PATH = "/Users/mike2ox/Project/webserve/html/redirect.html";
+const std::string DEFAULT_CONF_PATH = "./conf/sample.conf";
 
 #define SAMPLE_RESPONSE "HTTP/1.1 200 OK\r\n\
 Content-Length: 365\r\n\

--- a/main.cpp
+++ b/main.cpp
@@ -5,13 +5,11 @@ int main(int argc, char **argv) {
     FTServer ftServer;
 	std::string configFile;
 
-    if (argc != 2) {
-        std::cerr << "입력 인자 숫자 달라~ ... setting to default configuration file.\n";
-		configFile = "./conf/sample.conf";
-	} else {
+	if (argc != 2) {
+		configFile = DEFAULT_CONF_PATH;
+		Log::info("Set up default configuration file.");
+	} else
 		configFile = argv[1];
-	}
-	
 	try {
         ftServer.initParseConfig(configFile);
 		ftServer.init();
@@ -21,6 +19,5 @@ int main(int argc, char **argv) {
 		Log::error("VirtualServer::Fatal Error [%s]", excep.what());
 		// TODO: graceful shutdown process
 	}
-
     return 0;
 }


### PR DESCRIPTION
## Description
- 웹서브 내에 메모리 누수에 대해 해결
- throw로 전달할 message 작성

## Test
[setup]
- webserve 디렉토리에서 test
- configuration file, constant.hpp 정보는 test환경에 맞게 수정해주셔야 합니다.

[client1] `./webserve ./conf/sample.conf`
[client2] `while true; do; sudo leaks --atExit -- ./webserve conf/sample.conf; sleep 0.5; done;`