### PR TITLE
UNPQ-84 feat: modify file R/W called after kevent

### DIFF
--- a/Connection.cpp
+++ b/Connection.cpp
@@ -7,7 +7,8 @@
 Connection::Connection(port_t port, EventHandler& evHandler)
 : _client(false)
 , _hostPort(port)
-, _eventHandler(evHandler) {
+, _eventHandler(evHandler)
+, _targetVirtualServer(NULL) {
     this->newSocket();
     this->bindSocket();
     this->listenSocket();
@@ -26,7 +27,8 @@ Connection::Connection(int ident, std::string addr, port_t port, EventHandler& e
 , _hostPort(port)
 , _addr(addr)
 , _eventHandler(evHandler)
-, _closed(false) {
+, _closed(false)
+, _targetVirtualServer(NULL) {
     Log::verbose("New Client Connection: socket[%d]", _ident);
 }
 

--- a/Connection.hpp
+++ b/Connection.hpp
@@ -16,6 +16,8 @@
 
 #define TCP_MTU 1500
 
+class VirtualServer;
+
 typedef unsigned short port_t;
 
 //  General coonection handler, from generation communication.
@@ -28,7 +30,10 @@ typedef unsigned short port_t;
 //      _ident
 //      _addr
 //      _port
-//      _request
+//      _request: store request message and parse it.
+//      -response: store response message and send it to client.
+//
+//      _targetVirtualServer: the target to process request.
 //   - Methods
 class Connection {
 public:
@@ -41,6 +46,8 @@ public:
     port_t getPort() { return this->_hostPort; };
     const Request& getRequest() const { return this->_request; };
     bool isClosed() { return this->_closed; };
+    VirtualServer* getTargetVirtualServer() { return this->_targetVirtualServer; };
+    void setTargetVirtualServer(VirtualServer* targetVirtualServer) { this->_targetVirtualServer = targetVirtualServer; };
 
     Connection* acceptClient();
     EventContext::EventResult receive();
@@ -87,6 +94,8 @@ private:
 //    int _readEventTriggered;
 //    int _writeEventTriggered;
     bool _closed;
+
+    VirtualServer* _targetVirtualServer;
 
     Connection(int ident, std::string addr, port_t port, EventHandler& evHandler);
 

--- a/EventContext.cpp
+++ b/EventContext.cpp
@@ -20,5 +20,11 @@ std::string EventContext::getCallerTypeToString() {
 		return "EV_Response";
 	case EV_CGIResponse:
 		return "EV_CGIResponse";
+    case EV_SetVirtualServerErrorPage:
+        return "EV_SetVirtualServerErrorPage";
+    case EV_GETResponse:
+        return "EV_GETResponse";
+    case EV_POSTResponse:
+        return "EV_POSTResponse";
 	}
 }

--- a/EventContext.hpp
+++ b/EventContext.hpp
@@ -12,6 +12,9 @@ public:
 		EV_Request,
 		EV_Response,
 		EV_CGIResponse,
+        EV_SetVirtualServerErrorPage,
+        EV_GETResponse,
+        EV_POSTResponse,
 	};
 	enum EventResult {
 		ER_Done,

--- a/FTServer.hpp
+++ b/FTServer.hpp
@@ -75,6 +75,10 @@ private:
     EventContext::EventResult driveThisEvent(EventContext* context, int filter);
     void runEachEvent(struct kevent event);
     void callVirtualServerMethod(EventContext* context);
+
+    EventContext::EventResult eventSetVirtualServerErrorPage(EventContext& context);
+    EventContext::EventResult eventGETResponse(EventContext& context);
+    EventContext::EventResult eventPOSTResponse(EventContext& context);
 };
 
 #endif  // FTSERVER_HPP_


### PR DESCRIPTION
- reading error page file now called after kevent.
- reading GET target file now called after kevent.
- writing POST target file now called after kevent.

## Interface Description

요청에 따른 target virtual server를 반복적으로 계산하는 것을 피하기 위해 Connection 객체에 _targetVirtualServer 멤버 변수를 추가했습니다.
EventContext::EventType을 추가했습니다.
- EV_SetVirtualServerErrorPage: error page로 지정한 파일을 읽어야 함
- EV_GETResponse: GET의 요청 파일을 읽어야 함
- EV_POSTResponse: POST의 요청 파일을 써야 함

해당 이벤트 플래그와 함께 매칭되는 함수도 추가했습니다.

## Implementation Description

기존에 int를 반환하던 VirtualServer의 메서드들을 VirtualServer::ReturnCode 및 EventContext::EventType을 반환하도록 수정하였습니다.
VirtualServer의 몇몇 메서드들이 추가 인자로 EventHandler를 전달받도록 수정하였습니다.

## Test

make re && ./webserve custom.conf 자체 설정 파일 테스트를 통과했습니다.
GET, POST, DELETE가 전과 같이 잘 동작하는 것을 확인했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂