### PR TITLE
UNPQ-93 feat: read body until specified length

### DIFF
--- a/Connection.cpp
+++ b/Connection.cpp
@@ -77,6 +77,8 @@ EventContext::EventResult Connection::receive() {
 		break;
 	case RCRECV_PARSING_FINISH:
 		return this->passParsedRequest();
+    case RCRECV_ALREADY_PROCESSING_WAIT:
+        break;
 	}
 	return EventContext::ER_Continue;
 }

--- a/Connection.hpp
+++ b/Connection.hpp
@@ -54,6 +54,7 @@ public:
     EventContext::EventResult transmit();
     void dispose();
     void clearRequestMessage();
+    void resetRequestStatus() { this->_request.resetStatus(); };
     void clearResponseMessage();
     void appendResponseMessage(const std::string& message);
     EventContext::EventResult handleCGIResponse(int CGIPipeOut);

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -226,6 +226,7 @@ void FTServer::callVirtualServerMethod(EventContext* context) {
     VirtualServer::ReturnCode result;
 
     result = matchingServer.processRequest(*connection, this->_eventHandler);
+    connection->resetRequestStatus();
     switch (result) {
         case VirtualServer::RC_ERROR:
             break;


### PR DESCRIPTION
- now read body until receive specified length when received splitly.

## Interface Description

- Request::receive() 가 여러 횟수로 나뉘어 들어오는 요청 메세지를 제대로 가져오도록 수정하였습니다.(기존에는 body가 나뉘어 들어오는 경우를 제대로 처리하지 못했음)
- 한 connection에 대해 이미 처리 중인 요청이 존재할 경우 새로운 read 이벤트가 호출될 때, 기존 처리 중이던 요청이 처리되기 전에는 read 이벤트를 처리하지 않고 바로 반환되도록 수정하였습니다.(한 client connection에 대해 여러 request가 존재할 수 있도록 지원하기 위해서는 구조적인 조정이 필요하며, 이를 지원하는 것은 저희 프로젝트에 꼭 필요하지 않다고 판단했습니다.)
- 기존에 413이 405보다 앞에서 체크하던 것을 405가 413보다 앞에서 체크하도록 수정했습니다.
- GET과 DELETE도 413을 반환할 수 있도록 수정하였습니다.
- processRequest 에서 400과 411 응답에 걸리고도 정상적인 200 로직을 실행할 수 있던 문제를 수정하였습니다.

## Test

- make re && ./webserve custom.conf 자체 설정 파일 테스트를 통과했습니다.
- GET, POST, DELETE가 잘 동작하는 것을 확인했습니다.
- chunked body를 잘 처리하는 것을 확인했습니다.
- 기존에 server socket이 non-blocking 이 아니었던 것을 얼마 전 커밋에서 non-blocking으로 바꿈으로써 recv()가 한 번에 50 문자 정도를 읽어 와서, 그리 길지 않은 요청에도 불구하고 두 번에 걸처 recv()를 수행하는 것을 확인했습니다.
  - 이렇게 다수에 걸친 recv()를 통해 얻은 요청을 제대로 처리하는 것을 확인했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂