### PR TITLE
UNPQ-95 feat: update parsing in URL

### DIFF
--- a/Connection.cpp
+++ b/Connection.cpp
@@ -218,3 +218,15 @@ EventContext::EventResult Connection::passParsedRequest() {
 	);
 	return EventContext::ER_Done;
 }
+
+void Connection::parseCGIurl(std::string const &targetResourceURI, std::string const &targetExtention) {
+    const std::string::size_type targetExtBeginPos = targetResourceURI.find(targetExtention);
+    const std::string::size_type targetQueryBeginPos = targetResourceURI.find_first_of(std::string("?"), targetExtBeginPos);
+    std::string scriptName = targetResourceURI.substr(0, targetExtBeginPos + targetExtention.size());
+    std::string pathInfo = targetResourceURI.substr(targetExtBeginPos + targetExtention.size(), targetQueryBeginPos - (targetExtBeginPos + targetExtention.size()));
+    std::string queryString = targetResourceURI.substr(targetQueryBeginPos + 1);;
+
+    this->_request.updateParsedTarget(scriptName);
+    this->_request.updateParsedTarget(pathInfo);
+    this->_request.updateParsedTarget(queryString);
+}

--- a/Connection.hpp
+++ b/Connection.hpp
@@ -60,7 +60,8 @@ public:
     EventContext::EventResult handleCGIParamBody(int PipeToCGI);
     EventContext::EventResult handleCGIResponse(int PipeFromCGI);
     void addKevent(int filter, int fd, EventContext::EventType type, void* data);
-
+    void parseCGIurl(std::string const &targetResourceURI, std::string const &targetExtention);
+        
     class MAKESOCKETFAIL: public std::exception {
     public:
         virtual const char* what() const throw() {

--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -317,7 +317,7 @@ void FTServer::run() {
 //      Result flag of handled event
 EventContext::EventResult FTServer::driveThisEvent(EventContext* context, int filter) {
     Connection* connection = static_cast<Connection*>(context->getData());
-	if (filter != EVFILT_WRITE || filter != EVFILT_READ)
+	if (filter != EVFILT_WRITE && filter != EVFILT_READ)
 		return EventContext::ER_NA;
 	switch (context->getCallerType()) {
 	case EventContext::EV_Accept:

--- a/Request.cpp
+++ b/Request.cpp
@@ -273,6 +273,10 @@ HTTP::RequestMethod Request::requestMethodByString(const std::string& token) {
     return method;
 }
 
+inline void Request::updateParsedTarget(std::string parsed){    
+    this->_targetToken.push_back(parsed);
+}
+
 //  make value to lower case string.
 //  - Parameters value: the string to make lower case.
 //  - Return(None)

--- a/Request.cpp
+++ b/Request.cpp
@@ -273,7 +273,7 @@ HTTP::RequestMethod Request::requestMethodByString(const std::string& token) {
     return method;
 }
 
-inline void Request::updateParsedTarget(std::string parsed){    
+void Request::updateParsedTarget(std::string parsed){    
     this->_targetToken.push_back(parsed);
 }
 

--- a/Request.hpp
+++ b/Request.hpp
@@ -68,18 +68,21 @@ public:
     std::string getMessage() const { return this->_message; };
     const std::string* getFirstHeaderFieldValueByName(const std::string& name) const;
     const std::string& getBody() const { return this->_body; };
+    const std::vector<std::string> getTargetToken() const { return this->_targetToken; };
 
     void clearMessage();
     bool isParsingFail() const { return this->_parsingStatus == S_PARSING_FAIL; };
     bool isLengthRequired() const { return this->_parsingStatus == S_LENGTH_REQUIRED; };
 
     ReturnCaseOfRecv receive(int clientSocketFD);
+    void updateParsedTarget(std::string parsed);
 
 private:
     std::string _message;
 
     HTTP::RequestMethod _method;
     std::string _target;
+    std::vector<std::string> _targetToken;
     char _majorVersion;
     char _minorVersion;
 


### PR DESCRIPTION
## Description
- 요청하신 URL에서 `SCRINPT_INFO`,`PATH_INFO`, `QUERY_STRING` 3개의 token으로 파싱 완료
- (hotfix) event처리시 (!write || !read)라서 모든 이벤트를 ER_NA하는 오류 수정

## Issue
- `SCRINPT_INFO`,`PATH_INFO`, `QUERY_STRING`는 현재 connection->request에 **`_targetToken`**에 저장
- 현재 PR 은 UNPQ-50 에 merge하기 위한 PR입니다. 코드리뷰를 위해서 따로 브랜치를 생성 및 PR을 남긴겁니다.

## Test
- make re && ./webserve conf/sample.conf -> 정상동작 X
- **현재 지훈님 config에서는 root가 이상하게 적혀있어서 테스트는 안되지만 정상적으로 수정하면 제대로 동작하는걸 확인했습니다.**
- 확인하시고 코멘트 남겨주시면 감사하겠습니다.