### PR TITLE
UNPQ-29 fix: now pass siege with 100% availability

### DIFF
--- a/Connection.cpp
+++ b/Connection.cpp
@@ -1,4 +1,5 @@
 #include "Connection.hpp"
+#include "constant.hpp"
 
 // Constructor of Connection class ( no default constructor )
 // Generates a Connection instance for servers.
@@ -183,7 +184,7 @@ void Connection::bindSocket() {
 // Listen to the socket for incoming messages.
 //  - Return(none)
 void Connection::listenSocket() {
-    if (0 > listen(_ident, 10)) {
+    if (0 > listen(_ident, LISTEN_BACKLOG)) {
         throw Connection::LISTENSOCKETERROR();
     }
     if (fcntl(this->_ident, F_SETFL, O_NONBLOCK) == -1)

--- a/Log.cpp
+++ b/Log.cpp
@@ -31,29 +31,29 @@ void Log::printPrefixed(int logLevel, const char* format, va_list& va) {
 #if LOG_LEVEL >= 5
 void Log::verbose(const char* format, ...) { LOG_PRINT(LogVerbose) };
 #else
-void Log::verbose(const char* format, ...) {};
+void Log::verbose(const char* format, ...) { (void)format; };
 #endif
 
 #if LOG_LEVEL >= 4
 void Log::debug(const char* format, ...) { LOG_PRINT(LogDebug) };
 #else
-void Log::debug(const char* format, ...) {};
+void Log::debug(const char* format, ...) { (void)format; };
 #endif
 
 #if LOG_LEVEL >= 3
 void Log::info(const char* format, ...) { LOG_PRINT(LogInfo) };
 #else
-void Log::info(const char* format, ...) {};
+void Log::info(const char* format, ...) { (void)format; };
 #endif
 
 #if LOG_LEVEL >= 2
 void Log::warning(const char* format, ...) { LOG_PRINT(LogWarning) };
 #else
-void Log::warning(const char* format, ...) {};
+void Log::warning(const char* format, ...) { (void)format; };
 #endif
 
 #if LOG_LEVEL >= 1
 void Log::error(const char* format, ...) { LOG_PRINT(LogError) };
 #else
-void Log::error(const char* format, ...) {};
+void Log::error(const char* format, ...) { (void)format; };
 #endif

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -207,6 +207,9 @@ VirtualServer::ReturnCode VirtualServer::processGET(Connection& clientConnection
         clientConnection.appendResponseMessage("Connection: keep-alive\r\n");
         clientConnection.appendResponseMessage("\r\n");
 
+        if (buf.st_size == 0)
+            return RC_SUCCESS;
+
         const int targetFileFD = open(targetRepresentationURI.c_str(), O_RDONLY);
         if (targetFileFD == -1)
             return RC_ERROR;
@@ -244,6 +247,9 @@ VirtualServer::ReturnCode VirtualServer::processGET(Connection& clientConnection
         clientConnection.appendResponseMessage("\r\n");
         clientConnection.appendResponseMessage("Connection: keep-alive\r\n");
         clientConnection.appendResponseMessage("\r\n");
+
+        if (buf.st_size == 0)
+            return RC_SUCCESS;
 
         const int targetFileFD = open(location.getIndex().c_str(), O_RDONLY);
         if (targetFileFD == -1)

--- a/constant.hpp
+++ b/constant.hpp
@@ -1,7 +1,8 @@
 #ifndef CONSTANT_HPP_
 #define CONSTANT_HPP_
 
-const int BUF_SIZE = 1024;
+const int BUF_SIZE = 0x1 << 10;
+const int LISTEN_BACKLOG = 40;
 const std::string REDIRECT_PATH = "/Users/mike2ox/Project/webserve/html/redirect.html";
 const std::string DEFAULT_CONF_PATH = "./conf/sample.conf";
 


### PR DESCRIPTION
- fix a compile error when give option '-D LOG_LEVEL=0'.
- fix a bug where GET request won't process empty file.
- modify listen backlog from 10 to 40.

## Interface Description

`-D LOG_LEVEL=0` 옵션을 주었을 때 발생하던 컴파일 에러를 수정했습니다.
빈 파일에 GET 요청을 받았을 때 제대로 요청을 처리하지 못하던 문제를 수정하였습니다.
listen의 backlog를 10에서 40으로 증가시켰습니다.

## Test

make re && ./webserve custom.conf 자체 설정 파일 테스트를 통과했습니다.
siege를 100%로 통과하는 것을 확인했습니다.

리뷰 해주시고 문제 없으면 approve 해주시면 감사하겠습니다. 🙂