### PR TITLE
UNPQ-28 check 42 tester

### DIFF
--- a/FTServer.cpp
+++ b/FTServer.cpp
@@ -60,17 +60,20 @@ void FTServer::initParseConfig(std::string filePath) {
                 ServerConfigKey key;
                 directiveContainer tConfigs;
                 sc = new VirtualServerConfig();
-                if (!sc->parsing(fs, ss, confLine)) // fstream, stringstream를 전달해주는 방식으로 진행
-                    std::cerr << "not parsing config\n"; // 각 요소별 동적할당 해제시켜주는게 중요
+                if (!sc->parsing(fs, ss, confLine)) {
+                    Log::error("fail parsing config");
+                    delete sc;
+                    continue;
+                }
                 tConfigs = sc->getConfigs();
                 if (tConfigs.find("server_name") != tConfigs.end())
-                    key._server_name.push_back(tConfigs.find("server_name")->second[0]); // 가장 먼저 입력된 server_name 1개만
+                    key._server_name.push_back(tConfigs.find("server_name")->second[0]);
                 else
-                    key._server_name.push_back(""); // TODO server_name 비어있는 경우 "" 설정
+                    key._server_name.push_back("");
                 if (tConfigs.find("listen") != tConfigs.end())
                     key._port = tConfigs.find("listen")->second[0];
                 else {
-                    std::cerr << "not find listen value\n";
+                    Log::error("not find listen value");
                     delete sc;
                     continue;
                 }
@@ -80,12 +83,13 @@ void FTServer::initParseConfig(std::string filePath) {
                 }
                 this->_defaultConfigs.push_back(sc);
             } else
-                std::cerr << "not match (token != server)\n"; // (TODO) 오류터졌을 때 동적할당 해제 해줘야함
+                Log::error("token and server directive don't match");
             ss.clear();
         }
     }
     else
-        std::cerr << "not open file\n";
+        throw std::domain_error("not open file");
+    this->printParseResult();
 }
 
 //  Initialize server manager from server config set.
@@ -406,4 +410,52 @@ EventContext::EventResult FTServer::eventPOSTResponse(EventContext& context) {
     VirtualServer* targetVirtualServer = clientConnection->getTargetVirtualServer();
 
     return targetVirtualServer->eventPOSTResponse(context, this->_eventHandler);
+}
+void FTServer::printParseResult() {
+    // default 서버
+    // serverblock별
+    //      기본 설정판
+    //      location block별 판
+    int i = 1;
+    for(VirtualServerConfigIter vscItr = this->_defaultConfigs.begin();
+        vscItr != this->_defaultConfigs.end();
+        vscItr++) {
+            directiveContainer c =(*vscItr)->getConfigs();
+            std::cout << "==============   " << i <<  "th Server Config  =============\n";
+            std::cout << "==============   Basic Directives   =============\n";
+            for (directiveContainer::const_iterator cItr = c.begin();
+                cItr!= c.end();
+                cItr++) {
+                std::cout << std::setw(20) << std::left << cItr->first;
+                for (std::vector<std::string>::const_iterator cItr2 = cItr->second.begin();
+                    cItr2 != cItr->second.end();
+                    cItr2++)
+                    std::cout << *cItr2 << ' ';
+                std::cout << std::endl;
+            }
+            std::cout << std::endl;
+
+            std::set<LocationConfig *> l =(*vscItr)->getLocations();
+            std::cout << "===============     Locations      ===============\n";
+            for (std::set<LocationConfig *>::const_iterator lIter = l.begin();
+                lIter != l.end();
+                lIter++) {
+                directiveContainer c = (*lIter)->getDirectives();
+                std::cout << "==============  Location Directives ==============\n";
+                std::cout << std::setw(20) << std::left << "path ";
+                std::cout << (*lIter)->getPath() << '\n';
+                for (directiveContainer::const_iterator cItr = c.begin();
+                cItr!= c.end();
+                cItr++) {
+                std::cout << std::setw(20) << std::left  << cItr->first;
+                for (std::vector<std::string>::const_iterator cItr2 = cItr->second.begin();
+                    cItr2 != cItr->second.end();
+                    cItr2++)
+                    std::cout << *cItr2 << ' ';
+                std::cout << std::endl;
+            }
+            }
+            std::cout << "\n****************************************************\n"  << std::endl;
+            i++;
+        }
 }

--- a/FTServer.hpp
+++ b/FTServer.hpp
@@ -79,6 +79,7 @@ private:
     EventContext::EventResult eventSetVirtualServerErrorPage(EventContext& context);
     EventContext::EventResult eventGETResponse(EventContext& context);
     EventContext::EventResult eventPOSTResponse(EventContext& context);
+    void printParseResult();
 };
 
 #endif  // FTSERVER_HPP_

--- a/Location.cpp
+++ b/Location.cpp
@@ -30,10 +30,8 @@ int Location::getClientMaxBodySize() const {
         int maxBodySize;
         iss >> maxBodySize;
         if (!iss)
-            return INT_MAX;
-
+            return -1;
         return maxBodySize;
     }
-
-    return INT_MAX;
+    return -1;
 }

--- a/Location.hpp
+++ b/Location.hpp
@@ -40,7 +40,7 @@ public:
     };
     void setAutoIndex(bool isAutoindex) { this->_autoindex = isAutoindex; };
     void setAllowedHTTPMethod(std::vector<std::string> allowedMethod) {
-        char beAllowed = '0';
+        char beAllowed = '\0';
         for (std::vector<std::string>::const_iterator itr = allowedMethod.begin(); itr != allowedMethod.end(); itr++) {
             if (*itr == "GET")
                 beAllowed |= HTTP::RM_GET;
@@ -48,6 +48,10 @@ public:
                 beAllowed |= HTTP::RM_POST; 
             else if (*itr == "DELETE")
                 beAllowed |= HTTP::RM_DELETE;
+            else if (*itr == "PUT")
+                beAllowed |= HTTP::RM_PUT;
+            else
+                beAllowed |= HTTP::RM_UNKNOWN;
         }
         if (beAllowed)
             this->_allowedHTTPMethod = beAllowed;

--- a/Request.cpp
+++ b/Request.cpp
@@ -298,6 +298,8 @@ HTTP::RequestMethod Request::requestMethodByString(const std::string& token) {
         method = HTTP::RM_POST;
     else if (token == "DELETE")
         method = HTTP::RM_DELETE;
+    else if (token == "PUT")
+        method = HTTP::RM_PUT;
     else
         method = HTTP::RM_UNKNOWN;
 

--- a/Request.hpp
+++ b/Request.hpp
@@ -15,10 +15,11 @@ namespace HTTP {
 
 //  RequestMethod indicates request method type of HTTP request message.
 enum RequestMethod {
-    RM_UNKNOWN = 0x0,
     RM_GET = 0x1 << 0,
     RM_POST = 0x1 << 1,
     RM_DELETE = 0x1 << 2,
+    RM_PUT = 0x1 << 3,
+    RM_UNKNOWN = 0x1 << 4
 };
 
 }   // namespace HTTP

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -222,8 +222,8 @@ VirtualServer::ReturnCode VirtualServer::processGET(Connection& clientConnection
 
         return RC_IN_PROGRESS;
     }
-
-    if (stat(location.getIndex().c_str(), &buf) == 0
+    const std::string absoluteIndexPath = targetRepresentationURI + "/" + location.getIndex();
+    if (stat(absoluteIndexPath.c_str(), &buf) == 0
             && (buf.st_mode & S_IFREG) != 0) {
         this->appendStatusLine(clientConnection, Status::I_200);
 
@@ -250,8 +250,7 @@ VirtualServer::ReturnCode VirtualServer::processGET(Connection& clientConnection
 
         if (buf.st_size == 0)
             return RC_SUCCESS;
-
-        const int targetFileFD = open(location.getIndex().c_str(), O_RDONLY);
+        const int targetFileFD = open(absoluteIndexPath.c_str(), O_RDONLY);
         if (targetFileFD == -1)
             return RC_ERROR;
         if (fcntl(targetFileFD, F_SETFL, O_NONBLOCK) == -1) {

--- a/VirtualServer.cpp
+++ b/VirtualServer.cpp
@@ -23,12 +23,12 @@ const Status Status::_array[] = {
 static void updateContentType(const std::string& name, std::string& type);
 static void updateExtension(const std::string& name, std::string& extension);
 static void updateBodyString(HTTP::Status::Index index, const char* description, std::string& bodyString);
-
 //  Default constructor of VirtualServer.
 //  - Parameters(None)
 VirtualServer::VirtualServer() 
 : _portNumber(0),
-_name("")
+_name(""),
+_clientMaxBodySize(DEFAULT_CLIENT_MAX_BODY_SIZE)
 {
 } 
 
@@ -181,7 +181,10 @@ VirtualServer::ReturnCode VirtualServer::processGET(Connection& clientConnection
     }
     if (!location.isRequestMethodAllowed(request.getMethod()))
         return this->set405Response(clientConnection, &location);
-    if (request.getBody().length() > static_cast<std::string::size_type>(location.getClientMaxBodySize()))
+    int targetClientMaxBodysize = location.getClientMaxBodySize();
+    if (targetClientMaxBodysize < 0)
+        targetClientMaxBodysize = this->_clientMaxBodySize;
+    if (request.getBody().length() > static_cast<std::string::size_type>(targetClientMaxBodysize))
         return this->set413Response(clientConnection);
 
     location.updateRepresentationPath(targetResourceURI, targetRepresentationURI);
@@ -331,7 +334,10 @@ VirtualServer::ReturnCode VirtualServer::processPOST(Connection& clientConnectio
     }
     if (!location.isRequestMethodAllowed(request.getMethod()))
         return this->set405Response(clientConnection, &location);
-    if (request.getBody().length() > static_cast<std::string::size_type>(location.getClientMaxBodySize()))
+    int targetClientMaxBodysize = location.getClientMaxBodySize();
+    if (targetClientMaxBodysize < 0)
+        targetClientMaxBodysize = this->_clientMaxBodySize;
+    if (request.getBody().length() > static_cast<std::string::size_type>(targetClientMaxBodysize))
         return this->set413Response(clientConnection);
 
     location.updateRepresentationPath(targetResourceURI, targetRepresentationURI);
@@ -432,7 +438,10 @@ VirtualServer::ReturnCode VirtualServer::processDELETE(Connection& clientConnect
     }
     if (!location.isRequestMethodAllowed(request.getMethod()))
         return this->set405Response(clientConnection, &location);
-    if (request.getBody().length() > static_cast<std::string::size_type>(location.getClientMaxBodySize()))
+    int targetClientMaxBodysize = location.getClientMaxBodySize();
+    if (targetClientMaxBodysize < 0)
+        targetClientMaxBodysize = this->_clientMaxBodySize;
+    if (request.getBody().length() > static_cast<std::string::size_type>(targetClientMaxBodysize))
         return this->set413Response(clientConnection);
 
     location.updateRepresentationPath(targetResourceURI, targetRepresentationURI);

--- a/VirtualServer.hpp
+++ b/VirtualServer.hpp
@@ -132,6 +132,7 @@ private:
     void appendContentDefaultHeaderFields(Connection& clientConnection);
     void updateBodyString(HTTP::Status::Index index, const char* description, std::string& bodystring) const;
 
+    ReturnCode set201Response(Connection& clientConnection);
     ReturnCode set301Response(Connection& clientConnection, const std::map<std::string, std::vector<std::string> >& locOther);
     ReturnCode set308Response(Connection& clientConnection, const std::map<std::string, std::vector<std::string> >& locOther);
     ReturnCode set400Response(Connection& clientConnection);

--- a/VirtualServerConfig.cpp
+++ b/VirtualServerConfig.cpp
@@ -43,9 +43,8 @@ bool    VirtualServerConfig::parsing(std::fstream &fs, std::stringstream &ss, st
         return false;
     this->_inBrace = true;
     // token.clear();
-    ss >> token;
     while (true) {
-        if (!ss) {
+        if (ss.eof()) {
             if (!getline(fs, confLine)) // 스트림이 비어있고 가져올 줄이 없는 경우
                 break ;
             ss.clear();

--- a/conf/sample_for_tester.conf
+++ b/conf/sample_for_tester.conf
@@ -10,6 +10,11 @@ server {
     }
     location  /put_test/ {
         allow_method PUT GET;
+        index   youpi.bad_extension;
+        root    /goinfre/mosong/webserve/YoupiBanane/nop;
+    }
+    location   /post_body {
+        client_max_body_size 100;
         root    /goinfre/mosong/webserve/YoupiBanane;
     }
     location /directory {

--- a/conf/sample_for_tester.conf
+++ b/conf/sample_for_tester.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name localhost;
+    client_max_body_size 10000000;
+
+    location / {
+        allow_method GET;
+        autoindex on;
+        root    /goinfre/mosong/webserve/YoupiBanane;
+    }
+    location  /put_test/ {
+        allow_method PUT GET;
+        root    /goinfre/mosong/webserve/YoupiBanane;
+    }
+    location /directory {
+        allow_method GET POST;
+        cgi .cgi .bla;
+        cgi_path  /goinfre/mosong/webserve/cgi-bin; 
+        index   youpi.bad_extension;
+        root    /goinfre/mosong/webserve/YoupiBanane;
+    }
+}

--- a/constant.hpp
+++ b/constant.hpp
@@ -3,6 +3,7 @@
 
 const int BUF_SIZE = 0x1 << 10;
 const int LISTEN_BACKLOG = 40;
+const int DEFAULT_CLIENT_MAX_BODY_SIZE = 100000;
 const std::string REDIRECT_PATH = "/Users/mike2ox/Project/webserve/html/redirect.html";
 const std::string DEFAULT_CONF_PATH = "./conf/sample.conf";
 


### PR DESCRIPTION
## Description
- conf 파싱 완료시 어떤 conf들로 서버가 설정되었는지 확인 가능
- CGI직전까지 tester 통과 완료
- index 파일에 대한 정확한 경로 적용
- RM_UNKNOWN 설정값 변경

## Issue
-  테스터기에 있는 PUT뒤의 test를 보기위해 PUT이 올 경우 201로 강제로 출력하도록 했습니다
(PUT에 관련된 것들은 실제 제출에서는 주석처리해주고 평가때 활성화하는게 좋아보입니다.)

## Test
- `make re && ./webserve ./conf/sample_for_tester.conf` 현재 CGI직전까지 정상 통과합니다
- sample_for_tester.conf에서 path(TEST하는 PC에 맞게)와 dummy(ex.  YoupiBanane) 설정을 해주셔야 합니다.